### PR TITLE
Add external import rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ A plan to evolve Deply into a must-have architectural guardian for Python projec
   🔲 Dependency graph caching  
   🔲 Custom rules system  
   🔲 FastAPI/Django/Flask presets  
+  🔲 LLM skill creation helpers
   ✅ Third-party import restrictions (`disallow_external_imports`)
 
 ## Further Documentation

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ deply:
     views:
       disallow_layer_dependencies:
         - models
+
+    services:
+      disallow_external_imports:
+        - django
+        - requests
 ```
 
 ### Command-Line Usage
@@ -91,6 +96,7 @@ deply --help
 - **Layer-Based Analysis**: Define project layers and restrict their dependencies to enforce modularity.
 - **Dynamic Layer Configuration**: Easily configure collectors for each layer using file patterns, class inheritance, and logical conditions.
 - **Cross-Layer Dependency Rules**: Specify rules to disallow certain layers from accessing others.
+- **External Import Restrictions**: Prevent selected layers from importing framework, persistence, or SDK packages.
 - **Extensible and Configurable**: Customize layers and rules for any Python project setup.
 - **Mermaid Diagrams**: Visualize your architecture and dependencies with Mermaid diagrams.
 - **Error Suppression**: Suppress specific rule violations with inline comments.
@@ -102,6 +108,7 @@ Deply provides options to suppress rule violations using comments in your code:
 ```python
 # Line-level suppression
 user.get()  # deply:ignore:DISALLOW_LAYER_DEPENDENCIES
+import requests  # deply:ignore:DISALLOWED_EXTERNAL_IMPORT
 
 # File-level suppression (at the top of the file)
 # deply:ignore-file:ENFORCE_INHERITANCE
@@ -144,7 +151,7 @@ A plan to evolve Deply into a must-have architectural guardian for Python projec
   🔲 Dependency graph caching  
   🔲 Custom rules system  
   🔲 FastAPI/Django/Flask presets  
-  🔲 Third-party import restrictions (`disallow_external_imports`)  
+  ✅ Third-party import restrictions (`disallow_external_imports`)
 
 ## Further Documentation
 - [Core Concepts](https://vashkatsi.github.io/deply/doc/features.html) - Explains layers, rules and violations in more details.

--- a/deply.yaml.example
+++ b/deply.yaml.example
@@ -53,6 +53,11 @@ deply:
       disallow_layer_dependencies:
         - models
 
+    services:
+      disallow_external_imports:
+        - django
+        - requests
+
     tasks:
       enforce_function_decorator_usage:
         - type: function_decorator_name_regex

--- a/deply/deply_runner.py
+++ b/deply/deply_runner.py
@@ -181,6 +181,43 @@ class DeplyRunner:
                     if violation_candidate and not self.is_violation_suppressed(violation_candidate):
                         self.violations.add(violation_candidate)
 
+    def run_external_import_checks(self):
+        external_import_rules = [
+            rule for rule in self.rules if getattr(rule, "checks_external_imports", False)
+        ]
+        if not external_import_rules:
+            return
+
+        file_layer_elements: Dict[Tuple[Path, str], CodeElement] = {}
+        for element, layer_name in self.code_element_to_layer.items():
+            key = (element.file, layer_name)
+            current_element = file_layer_elements.get(key)
+            if current_element is None or (
+                    element.line,
+                    element.column,
+                    element.name,
+            ) < (
+                    current_element.line,
+                    current_element.column,
+                    current_element.name,
+            ):
+                file_layer_elements[key] = element
+
+        imports_by_file: Dict[Path, List[Tuple[str, int, int]]] = {}
+        for (file_path, layer_name), element in file_layer_elements.items():
+            imports = imports_by_file.setdefault(file_path, extract_absolute_imports(file_path))
+            for module_name, line, column in imports:
+                for rule in external_import_rules:
+                    violation_candidate = rule.check_external_import(
+                        layer_name,
+                        element,
+                        module_name,
+                        line,
+                        column,
+                    )
+                    if violation_candidate and not self.is_violation_suppressed(violation_candidate):
+                        self.violations.add(violation_candidate)
+
     def generate_report(self):
         logging.info("Generating report...")
         return ReportGenerator(list(self.violations)).generate(self.args.report_format)
@@ -206,10 +243,33 @@ class DeplyRunner:
         self.prepare_rules()
         self.analyze_dependencies()
         self.run_element_based_checks()
+        self.run_external_import_checks()
         report = self.generate_report()
         self.output_report(report)
 
         return len(self.violations) <= self.args.max_violations
+
+
+def extract_absolute_imports(file_path: Path) -> List[Tuple[str, int, int]]:
+    imports: List[Tuple[str, int, int]] = []
+    try:
+        source_code = file_path.read_text(encoding="utf-8")
+        file_ast = ast.parse(source_code, filename=str(file_path))
+    except Exception as ex:
+        logging.debug(f"Skipping external import checks for {file_path}: {ex}")
+        return imports
+
+    for node in ast.walk(file_ast):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imports.append((alias.name, node.lineno, node.col_offset))
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:
+                continue
+            if node.module:
+                imports.append((node.module, node.lineno, node.col_offset))
+
+    return imports
 
 
 def process_file(file_path: Path, layer_collectors: List[Tuple[str, Any]]) -> Tuple[str, List[Tuple[str, CodeElement]], IgnoreMap]:

--- a/deply/models/violation_types.py
+++ b/deply/models/violation_types.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 class ViolationType(Enum):
     DISALLOWED_DEPENDENCY = ("disallowed_dependency", "Disallowed Dependency")
+    DISALLOWED_EXTERNAL_IMPORT = ("disallowed_external_import", "Disallowed External Import")
     FUNCTION_DECORATOR_USAGE = ("function_decorator_usage", "Function Decorator Usage")
     CLASS_DECORATOR_USAGE = ("class_decorator_usage", "Class Decorator Usage")
     CLASS_NAMING = ("class_naming", "Class Naming")

--- a/deply/rules/__init__.py
+++ b/deply/rules/__init__.py
@@ -1,3 +1,4 @@
 from .base_rule import BaseRule as BaseRule
 from .dependency_rule import DependencyRule as DependencyRule
+from .external_import_rule import ExternalImportRule as ExternalImportRule
 from .rule_factory import RuleFactory as RuleFactory

--- a/deply/rules/base_rule.py
+++ b/deply/rules/base_rule.py
@@ -5,6 +5,8 @@ from ..models.code_element import CodeElement
 
 
 class BaseRule:
+    checks_external_imports = False
+
     def check(
             self,
             source_layer: str,
@@ -18,5 +20,15 @@ class BaseRule:
             self,
             layer_name: str,
             element: CodeElement
+    ) -> Optional[Violation]:
+        return None
+
+    def check_external_import(
+            self,
+            layer_name: str,
+            element: CodeElement,
+            module_name: str,
+            line: int,
+            column: int
     ) -> Optional[Violation]:
         return None

--- a/deply/rules/external_import_rule.py
+++ b/deply/rules/external_import_rule.py
@@ -1,0 +1,47 @@
+from typing import List, Optional
+
+from deply.models.code_element import CodeElement
+from deply.models.violation import Violation
+from deply.models.violation_types import ViolationType
+from deply.rules.base_rule import BaseRule
+
+
+class ExternalImportRule(BaseRule):
+    VIOLATION_TYPE = ViolationType.DISALLOWED_EXTERNAL_IMPORT
+    checks_external_imports = True
+
+    def __init__(self, layer_name: str, disallowed_imports: List[str]):
+        self.layer_name = layer_name
+        self.disallowed_import_roots = {
+            import_name.split(".")[0]
+            for import_name in disallowed_imports
+            if import_name
+        }
+
+    def check_external_import(
+            self,
+            layer_name: str,
+            element: CodeElement,
+            module_name: str,
+            line: int,
+            column: int
+    ) -> Optional[Violation]:
+        if layer_name != self.layer_name:
+            return None
+
+        import_root = module_name.split(".")[0]
+        if import_root not in self.disallowed_import_roots:
+            return None
+
+        return Violation(
+            file=element.file,
+            element_name=element.name,
+            element_type=element.element_type,
+            line=line,
+            column=column,
+            message=(
+                f"Layer '{layer_name}' is not allowed to import external package "
+                f"'{import_root}'. Import: {module_name}."
+            ),
+            violation_type=self.VIOLATION_TYPE,
+        )

--- a/deply/rules/rule_factory.py
+++ b/deply/rules/rule_factory.py
@@ -7,6 +7,7 @@ from .class_decorator_rule import ClassDecoratorUsageRule
 from .function_decorator_rule import FunctionDecoratorUsageRule
 from .inheritance_rule import InheritanceRule
 from .bool_rule import BoolRule
+from .external_import_rule import ExternalImportRule
 
 
 class RuleFactory:
@@ -26,6 +27,10 @@ class RuleFactory:
             disallowed = layer_rules.get("disallow_layer_dependencies")
             if disallowed:
                 rules.append(DependencyRule(layer_name, disallowed))
+
+            disallowed_external_imports = layer_rules.get("disallow_external_imports")
+            if disallowed_external_imports:
+                rules.append(ExternalImportRule(layer_name, disallowed_external_imports))
 
             rules.extend(
                 RuleFactory._collect_rules_for_key(layer_name, layer_rules, "enforce_class_naming")

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -64,6 +64,10 @@ ruleset:
   views:
     disallow_layer_dependencies:
       - models
+  domain:
+    disallow_external_imports:
+      - django
+      - requests
 ```
 
 ### Collectors
@@ -99,6 +103,10 @@ ruleset:
     enforce_function_decorator_usage:
       - type: function_decorator_name_regex
         decorator_name_regex: "app.task"
+  domain:
+    disallow_external_imports:
+      - django
+      - sqlalchemy
 ```
 
 ## Best Practices

--- a/doc/rules.md
+++ b/doc/rules.md
@@ -33,6 +33,22 @@ ruleset:
         decorator_name_regex: "app.task"
 ```
 
+### External Import Rules
+
+Prevent selected layers from importing configured package roots:
+
+```yaml
+ruleset:
+  domain:
+    disallow_external_imports:
+      - django
+      - sqlalchemy
+      - requests
+```
+
+This flags `import requests` and `from django.db import models` in `domain`.
+Relative project imports such as `from .models import User` are ignored.
+
 ### Class Inheritance Rules
 
 Ensure classes inherit from specific base classes:
@@ -95,6 +111,10 @@ ruleset:
     enforce_function_decorator_usage:
       - type: function_decorator_name_regex
         decorator_name_regex: "app.task"
+  domain:
+    disallow_external_imports:
+      - django
+      - sqlalchemy
 ```
 
 ## Best Practices

--- a/tests/test_external_import_rule.py
+++ b/tests/test_external_import_rule.py
@@ -1,0 +1,336 @@
+import argparse
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+from deply.deply_runner import DeplyRunner, extract_absolute_imports
+from deply.models.code_element import CodeElement
+from deply.models.violation_types import ViolationType
+from deply.rules.external_import_rule import ExternalImportRule
+
+
+class TestExternalImportRule(unittest.TestCase):
+    def setUp(self):
+        self.element = CodeElement(
+            file=Path("domain/service.py"),
+            name="load_user",
+            element_type="function",
+            line=4,
+            column=0,
+        )
+
+    def test_import_root_violation(self):
+        rule = ExternalImportRule("domain", ["requests"])
+
+        violation = rule.check_external_import("domain", self.element, "requests.sessions", 1, 0)
+
+        self.assertIsNotNone(violation)
+        self.assertEqual(violation.violation_type, ViolationType.DISALLOWED_EXTERNAL_IMPORT)
+        self.assertEqual(violation.line, 1)
+        self.assertIn("external package 'requests'", violation.message)
+
+    def test_unconfigured_import_passes(self):
+        rule = ExternalImportRule("domain", ["django"])
+
+        violation = rule.check_external_import("domain", self.element, "requests", 1, 0)
+
+        self.assertIsNone(violation)
+
+    def test_wrong_layer_passes(self):
+        rule = ExternalImportRule("domain", ["requests"])
+
+        violation = rule.check_external_import("infrastructure", self.element, "requests", 1, 0)
+
+        self.assertIsNone(violation)
+
+    def test_configured_nested_import_is_treated_as_root(self):
+        rule = ExternalImportRule("domain", ["django.db"])
+
+        violation = rule.check_external_import("domain", self.element, "django.forms", 1, 0)
+
+        self.assertIsNotNone(violation)
+        self.assertIn("external package 'django'", violation.message)
+
+    def test_root_name_must_match_exactly(self):
+        rule = ExternalImportRule("domain", ["request"])
+
+        violation = rule.check_external_import("domain", self.element, "requests", 1, 0)
+
+        self.assertIsNone(violation)
+
+
+class TestExternalImportExtraction(unittest.TestCase):
+    def test_extract_absolute_imports_handles_aliases_and_multiple_names(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            file_path = Path(temporary_directory) / "service.py"
+            file_path.write_text(
+                "import requests as http, django.db\n"
+                "from sqlalchemy.orm import Session\n"
+                "from ccxt.pro import binance\n"
+                "from .entities import User\n"
+                "from ..shared import Money\n"
+            )
+
+            imports = extract_absolute_imports(file_path)
+
+        self.assertEqual(
+            imports,
+            [
+                ("requests", 1, 0),
+                ("django.db", 1, 0),
+                ("sqlalchemy.orm", 2, 0),
+                ("ccxt.pro", 3, 0),
+            ],
+        )
+
+    def test_extract_absolute_imports_returns_empty_on_parse_error(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            file_path = Path(temporary_directory) / "invalid.py"
+            file_path.write_text("def invalid(:\n")
+
+            imports = extract_absolute_imports(file_path)
+
+        self.assertEqual(imports, [])
+
+
+class TestExternalImportRunner(unittest.TestCase):
+    def test_runner_reports_external_imports_and_skips_relative_imports(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            project_path = Path(temporary_directory) / "test_project"
+            domain_path = project_path / "domain"
+            domain_path.mkdir(parents=True)
+            (domain_path / "entities.py").write_text("class User:\n    pass\n")
+            (domain_path / "service.py").write_text(
+                "import requests\n"
+                "from django.db import models\n"
+                "from .entities import User\n"
+                "\n"
+                "def load_user():\n"
+                "    return User()\n"
+            )
+            config_path = Path(temporary_directory) / "deply.yaml"
+            config_path.write_text(
+                yaml.dump(
+                    {
+                        "deply": {
+                            "paths": [str(project_path)],
+                            "layers": [
+                                {
+                                    "name": "domain",
+                                    "collectors": [
+                                        {
+                                            "type": "file_regex",
+                                            "regex": ".*/domain/service.py",
+                                        }
+                                    ],
+                                }
+                            ],
+                            "ruleset": {
+                                "domain": {
+                                    "disallow_external_imports": [
+                                        "requests",
+                                        "django",
+                                        "entities",
+                                    ]
+                                }
+                            },
+                        }
+                    }
+                )
+            )
+            runner = DeplyRunner(
+                argparse.Namespace(
+                    config=str(config_path),
+                    parallel=None,
+                    report_format="json",
+                    output=None,
+                    mermaid=False,
+                    max_violations=0,
+                )
+            )
+
+            with patch("sys.stdout", new=io.StringIO()) as output_stream:
+                result = runner.run()
+
+        payload = json.loads(output_stream.getvalue())
+
+        self.assertFalse(result)
+        self.assertEqual(payload["total_violations"], 2)
+        self.assertEqual(payload["by_type"]["disallowed_external_import"], 2)
+        self.assertEqual(
+            sorted(violation["line"] for violation in payload["violations"]),
+            [1, 2],
+        )
+
+    def test_runner_applies_line_suppression(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            project_path = Path(temporary_directory) / "test_project"
+            domain_path = project_path / "domain"
+            domain_path.mkdir(parents=True)
+            (domain_path / "service.py").write_text(
+                "import requests  # deply:ignore:DISALLOWED_EXTERNAL_IMPORT\n"
+                "\n"
+                "def load_user():\n"
+                "    return None\n"
+            )
+            config_path = Path(temporary_directory) / "deply.yaml"
+            config_path.write_text(
+                yaml.dump(
+                    {
+                        "deply": {
+                            "paths": [str(project_path)],
+                            "layers": [
+                                {
+                                    "name": "domain",
+                                    "collectors": [
+                                        {
+                                            "type": "file_regex",
+                                            "regex": ".*/domain/service.py",
+                                        }
+                                    ],
+                                }
+                            ],
+                            "ruleset": {
+                                "domain": {
+                                    "disallow_external_imports": ["requests"]
+                                }
+                            },
+                        }
+                    }
+                )
+            )
+            runner = DeplyRunner(
+                argparse.Namespace(
+                    config=str(config_path),
+                    parallel=None,
+                    report_format="json",
+                    output=None,
+                    mermaid=False,
+                    max_violations=0,
+                )
+            )
+
+            with patch("sys.stdout", new=io.StringIO()) as output_stream:
+                result = runner.run()
+
+        payload = json.loads(output_stream.getvalue())
+
+        self.assertTrue(result)
+        self.assertEqual(payload["total_violations"], 0)
+
+    def test_runner_applies_file_level_suppression(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            project_path = Path(temporary_directory) / "test_project"
+            domain_path = project_path / "domain"
+            domain_path.mkdir(parents=True)
+            (domain_path / "service.py").write_text(
+                "# deply:ignore-file:DISALLOWED_EXTERNAL_IMPORT\n"
+                "import requests\n"
+                "\n"
+                "def load_user():\n"
+                "    return None\n"
+            )
+            config_path = Path(temporary_directory) / "deply.yaml"
+            config_path.write_text(
+                yaml.dump(
+                    {
+                        "deply": {
+                            "paths": [str(project_path)],
+                            "layers": [
+                                {
+                                    "name": "domain",
+                                    "collectors": [
+                                        {
+                                            "type": "file_regex",
+                                            "regex": ".*/domain/service.py",
+                                        }
+                                    ],
+                                }
+                            ],
+                            "ruleset": {
+                                "domain": {
+                                    "disallow_external_imports": ["requests"]
+                                }
+                            },
+                        }
+                    }
+                )
+            )
+            runner = DeplyRunner(
+                argparse.Namespace(
+                    config=str(config_path),
+                    parallel=None,
+                    report_format="json",
+                    output=None,
+                    mermaid=False,
+                    max_violations=0,
+                )
+            )
+
+            with patch("sys.stdout", new=io.StringIO()) as output_stream:
+                result = runner.run()
+
+        payload = json.loads(output_stream.getvalue())
+
+        self.assertTrue(result)
+        self.assertEqual(payload["total_violations"], 0)
+
+    def test_runner_ignores_files_without_collected_layer_elements(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            project_path = Path(temporary_directory) / "test_project"
+            domain_path = project_path / "domain"
+            domain_path.mkdir(parents=True)
+            (domain_path / "empty.py").write_text("import requests\n")
+            config_path = Path(temporary_directory) / "deply.yaml"
+            config_path.write_text(
+                yaml.dump(
+                    {
+                        "deply": {
+                            "paths": [str(project_path)],
+                            "layers": [
+                                {
+                                    "name": "domain",
+                                    "collectors": [
+                                        {
+                                            "type": "file_regex",
+                                            "regex": ".*/domain/empty.py",
+                                        }
+                                    ],
+                                }
+                            ],
+                            "ruleset": {
+                                "domain": {
+                                    "disallow_external_imports": ["requests"]
+                                }
+                            },
+                        }
+                    }
+                )
+            )
+            runner = DeplyRunner(
+                argparse.Namespace(
+                    config=str(config_path),
+                    parallel=None,
+                    report_format="json",
+                    output=None,
+                    mermaid=False,
+                    max_violations=0,
+                )
+            )
+
+            with patch("sys.stdout", new=io.StringIO()) as output_stream:
+                result = runner.run()
+
+        payload = json.loads(output_stream.getvalue())
+
+        self.assertTrue(result)
+        self.assertEqual(payload["total_violations"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rule_factory.py
+++ b/tests/test_rule_factory.py
@@ -2,6 +2,7 @@ import unittest
 
 from deply.rules.bool_rule import BoolRule
 from deply.rules.class_decorator_rule import ClassDecoratorUsageRule
+from deply.rules.external_import_rule import ExternalImportRule
 from deply.rules.function_decorator_rule import FunctionDecoratorUsageRule
 from deply.rules.rule_factory import RuleFactory
 
@@ -25,6 +26,18 @@ class TestRuleFactory(unittest.TestCase):
 
         self.assertIsInstance(function_decorator_rule, FunctionDecoratorUsageRule)
         self.assertIsInstance(class_decorator_rule, ClassDecoratorUsageRule)
+
+    def test_create_rules_for_external_imports(self):
+        rules = RuleFactory.create_rules(
+            {
+                "domain": {
+                    "disallow_external_imports": ["django", "requests"],
+                }
+            }
+        )
+
+        self.assertEqual(len(rules), 1)
+        self.assertIsInstance(rules[0], ExternalImportRule)
 
     def test_create_rule_from_config_for_bool_and_unknown_type(self):
         bool_rule = RuleFactory._create_rule_from_config(


### PR DESCRIPTION
## Summary
- Add `disallow_external_imports` layer rule for configured package-root deny lists.
- Report `disallowed_external_import` violations for absolute imports and support `DISALLOWED_EXTERNAL_IMPORT` suppression.
- Document the new rule and add a roadmap item for LLM skill creation helpers.

## Test Plan
- `make check`
- `git diff --check`

## Notes
- Relative imports are ignored.
- External imports do not add Mermaid dependency edges because they have no Deply layer target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for restricting certain layers from importing specific external packages.
  * Expanded configuration examples and docs to show how to define and use these rules.

* **Bug Fixes**
  * External import violations are now detected during analysis and reported with file and line details.
  * Relative imports are ignored, while nested package imports are matched by their root package.

* **Tests**
  * Added coverage for external import checks, suppression handling, import extraction, and rule creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->