### PR TITLE
Harden mutation test coverage

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -1,7 +1,6 @@
 import unittest
 import tempfile
 import shutil
-import os
 from pathlib import Path
 import sys
 import yaml
@@ -50,7 +49,7 @@ class TestCodeAnalyzer(unittest.TestCase):
         self.config_yaml = Path(self.test_dir) / 'config.yaml'
         config_data = {
             'deply': {
-                'paths': ['./test_project'],
+                'paths': [str(self.test_project_dir)],
                 'layers': [
                     {
                         'name': 'models',
@@ -86,25 +85,19 @@ class TestCodeAnalyzer(unittest.TestCase):
         shutil.rmtree(self.test_dir)
 
     def test_code_analyzer(self):
-        # Change current directory to the test directory
-        old_cwd = os.getcwd()
-        os.chdir(self.test_dir)
-        try:
-            # Capture the output
-            with captured_output() as (out, err):
-                try:
-                    # Run main with the test config
-                    sys.argv = ['main.py', 'analyze', '--config', str(self.config_yaml)]
-                    main()
-                except SystemExit as e:
-                    exit_code = e.code
-            output = out.getvalue()
-            # Check that the exit code is 1 (violations found)
-            self.assertEqual(exit_code, 1)
-            # Check that the output contains the expected violation message
-            self.assertIn("Layer 'views' is not allowed to depend on layer 'models'", output)
-        finally:
-            os.chdir(old_cwd)
+        # Capture the output
+        with captured_output() as (out, err):
+            try:
+                # Run main with the test config
+                sys.argv = ['main.py', 'analyze', '--config', str(self.config_yaml)]
+                main()
+            except SystemExit as e:
+                exit_code = e.code
+        output = out.getvalue()
+        # Check that the exit code is 1 (violations found)
+        self.assertEqual(exit_code, 1)
+        # Check that the output contains the expected violation message
+        self.assertIn("Layer 'views' is not allowed to depend on layer 'models'", output)
 
 
 if __name__ == '__main__':

--- a/tests/test_bool_rule.py
+++ b/tests/test_bool_rule.py
@@ -1,0 +1,37 @@
+import unittest
+from pathlib import Path
+
+from deply.models.code_element import CodeElement
+from deply.rules.bool_rule import BoolRule
+
+
+class TestBoolRule(unittest.TestCase):
+    def test_any_of_passes_when_later_rule_matches(self):
+        element = CodeElement(
+            file=Path("service.py"),
+            name="allowed_function",
+            element_type="function",
+            line=3,
+            column=0,
+        )
+        rule = BoolRule(
+            "service",
+            {
+                "any_of": [
+                    {
+                        "type": "function_name_regex",
+                        "function_name_regex": "^missing_.*$",
+                    },
+                    {
+                        "type": "function_name_regex",
+                        "function_name_regex": "^allowed_.*$",
+                    },
+                ],
+            },
+        )
+
+        self.assertIsNone(rule.check_element("service", element))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_class_method_call_violation.py
+++ b/tests/test_class_method_call_violation.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 import sys
 import tempfile
@@ -77,7 +76,7 @@ class TestClassMethodCallViolation(unittest.TestCase):
         self.config_yaml = Path(self.test_dir) / 'config.yaml'
         config_data = {
             'deply': {
-                'paths': ['./test_project'],
+                'paths': [str(self.test_project_dir)],
                 'layers': [
                     {
                         'name': 'models',
@@ -113,26 +112,20 @@ class TestClassMethodCallViolation(unittest.TestCase):
         shutil.rmtree(self.test_dir)
 
     def test_code_analyzer(self):
-        # Change current directory to the test directory
-        old_cwd = os.getcwd()
-        os.chdir(self.test_dir)
-        try:
-            # Capture the output
-            with captured_output() as (out, err):
-                try:
-                    # Run main with the test config
-                    sys.argv = ['main.py', 'analyze', '--config', str(self.config_yaml)]
-                    main()
-                except SystemExit as e:
-                    exit_code = e.code
-            output = out.getvalue()
-            # Check that the exit code is 1 (violations found)
-            self.assertEqual(exit_code, 1)
-            # Check that the output contains the expected violation message
-            self.assertIn("Layer 'views' is not allowed to depend on layer 'models'", output)
-            self.assertIn("Total Violations               17", output)
-        finally:
-            os.chdir(old_cwd)
+        # Capture the output
+        with captured_output() as (out, err):
+            try:
+                # Run main with the test config
+                sys.argv = ['main.py', 'analyze', '--config', str(self.config_yaml)]
+                main()
+            except SystemExit as e:
+                exit_code = e.code
+        output = out.getvalue()
+        # Check that the exit code is 1 (violations found)
+        self.assertEqual(exit_code, 1)
+        # Check that the output contains the expected violation message
+        self.assertIn("Layer 'views' is not allowed to depend on layer 'models'", output)
+        self.assertIn("Total Violations               17", output)
 
 
 if __name__ == '__main__':

--- a/tests/test_dependency_visitor.py
+++ b/tests/test_dependency_visitor.py
@@ -22,6 +22,7 @@ class TestDependencyVisitor(unittest.TestCase):
         source_code = textwrap.dedent(
             """
             import package.module as imported_module
+            import another.module
             from package.other import ImportedSymbol as imported_symbol
 
             def source_function():
@@ -38,6 +39,7 @@ class TestDependencyVisitor(unittest.TestCase):
         source_class_element = self._build_code_element("SourceClass", "class")
 
         imported_module_element = self._build_code_element("imported_module_dependency", "variable")
+        another_module_element = self._build_code_element("another_module_dependency", "variable")
         imported_symbol_element = self._build_code_element("imported_symbol_dependency", "class")
 
         captured_dependencies = []
@@ -50,6 +52,7 @@ class TestDependencyVisitor(unittest.TestCase):
             dependency_handler=captured_dependencies.append,
             name_to_elements={
                 "imported_module": {imported_module_element},
+                "another": {another_module_element},
                 "imported_symbol": {imported_symbol_element},
             },
         )
@@ -70,19 +73,77 @@ class TestDependencyVisitor(unittest.TestCase):
         expected_dependencies = {
             ("import", "source_function", "imported_module_dependency", 2, 0),
             ("import", "SourceClass", "imported_module_dependency", 2, 0),
-            ("import_from", "source_function", "imported_symbol_dependency", 3, 0),
-            ("import_from", "SourceClass", "imported_symbol_dependency", 3, 0),
+            ("import", "source_function", "another_module_dependency", 3, 0),
+            ("import", "SourceClass", "another_module_dependency", 3, 0),
+            ("import_from", "source_function", "imported_symbol_dependency", 4, 0),
+            ("import_from", "SourceClass", "imported_symbol_dependency", 4, 0),
+        }
+        self.assertEqual(actual_dependencies, expected_dependencies)
+
+    def test_visit_collects_function_call_attribute_call_and_inheritance_dependencies(self):
+        source_code = textwrap.dedent(
+            """
+            class Base:
+                pass
+
+            class Child(Base):
+                def method(self):
+                    helper()
+                    service.run()
+            """
+        )
+        syntax_tree = ast.parse(source_code)
+        set_ast_parents(syntax_tree)
+
+        child_element = self._build_code_element("Child", "class")
+        method_element = self._build_code_element("Child.method", "function")
+        base_element = self._build_code_element("Base", "class")
+        helper_element = self._build_code_element("helper", "function")
+        run_element = self._build_code_element("service.run", "function")
+
+        captured_dependencies = []
+        visitor = DependencyVisitor(
+            code_elements_in_file={
+                "Child": child_element,
+                "Child.method": method_element,
+            },
+            dependency_types=["class_inheritance", "function_call"],
+            dependency_handler=captured_dependencies.append,
+            name_to_elements={
+                "Base": {base_element},
+                "helper": {helper_element},
+                "service.run": {run_element},
+            },
+        )
+
+        visitor.visit(syntax_tree)
+
+        actual_dependencies = {
+            (
+                dependency.dependency_type,
+                dependency.code_element.name,
+                dependency.depends_on_code_element.name,
+                dependency.line,
+                dependency.column,
+            )
+            for dependency in captured_dependencies
+        }
+
+        expected_dependencies = {
+            ("class_inheritance", "Child", "Base", 5, 12),
+            ("function_call", "Child.method", "helper", 7, 8),
+            ("function_call", "Child.method", "service.run", 8, 8),
         }
         self.assertEqual(actual_dependencies, expected_dependencies)
 
     def test_visit_class_and_function_collects_decorator_annotation_and_metaclass_dependencies(self):
         source_code = textwrap.dedent(
             """
-            @function_decorator
+            @function_decorator()
             def source_function(parameter_annotation: ParameterType) -> ReturnType:
                 return 1
 
-            @class_decorator
+            @class_decorator()
             class SourceClass(metaclass=MetaClass):
                 pass
             """
@@ -171,6 +232,41 @@ class TestDependencyVisitor(unittest.TestCase):
             ),
         }
         self.assertEqual(actual_dependencies, expected_dependencies)
+
+    def test_visit_name_load_collects_dependency_for_loaded_names(self):
+        source_code = textwrap.dedent(
+            """
+            def source_function():
+                return shared_value
+            """
+        )
+        syntax_tree = ast.parse(source_code)
+        set_ast_parents(syntax_tree)
+
+        source_function_element = self._build_code_element("source_function", "function")
+        shared_value_element = self._build_code_element("shared_value", "variable")
+
+        captured_dependencies = []
+        visitor = DependencyVisitor(
+            code_elements_in_file={
+                "source_function": source_function_element,
+            },
+            dependency_types=["name_load"],
+            dependency_handler=captured_dependencies.append,
+            name_to_elements={
+                "shared_value": {shared_value_element},
+            },
+        )
+
+        visitor.visit(syntax_tree)
+
+        self.assertEqual(len(captured_dependencies), 1)
+        dependency = captured_dependencies[0]
+        self.assertEqual(dependency.dependency_type, "name_load")
+        self.assertEqual(dependency.code_element, source_function_element)
+        self.assertEqual(dependency.depends_on_code_element, shared_value_element)
+        self.assertEqual(dependency.line, 3)
+        self.assertEqual(dependency.column, 11)
 
     def test_get_full_name_handles_subscript_constant_index_and_fallback(self):
         visitor = DependencyVisitor(

--- a/tests/test_deply_runner.py
+++ b/tests/test_deply_runner.py
@@ -1,5 +1,6 @@
 import argparse
 import io
+import re
 import tempfile
 import unittest
 from pathlib import Path
@@ -7,8 +8,10 @@ from unittest.mock import MagicMock, patch
 
 from deply.deply_runner import DeplyRunner, process_file
 from deply.models.code_element import CodeElement
+from deply.models.dependency import Dependency
 from deply.models.violation import Violation
 from deply.models.violation_types import ViolationType
+from deply.rules.dependency_rule import DependencyRule
 
 
 class TestDeplyRunnerArguments(unittest.TestCase):
@@ -112,6 +115,12 @@ class TestDeplyRunnerBehavior(unittest.TestCase):
 
         self.assertFalse(self.runner.is_violation_suppressed(violation))
 
+    def test_is_violation_not_suppressed_when_file_has_no_ignore_map(self):
+        violation = self._build_violation(Path("/tmp/missing_ignore_map.py"), line=20)
+        self.runner.ignore_maps = {}
+
+        self.assertFalse(self.runner.is_violation_suppressed(violation))
+
     def test_output_report_writes_to_file_when_output_path_is_provided(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             output_path = Path(temporary_directory) / "report.txt"
@@ -154,6 +163,63 @@ class TestDeplyRunnerBehavior(unittest.TestCase):
                 self.runner.collect_all_files()
 
         self.assertEqual(self.runner.all_files, [])
+
+    def test_collect_all_files_applies_exclude_patterns_to_relative_paths(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            base_path = Path(temporary_directory)
+            keep_file_path = base_path / "keep.py"
+            ignored_file_path = base_path / "generated" / "ignored.py"
+            ignored_file_path.parent.mkdir()
+            keep_file_path.write_text("class Keep:\n    pass\n")
+            ignored_file_path.write_text("class Ignored:\n    pass\n")
+            self.runner.paths = [base_path]
+            self.runner.exclude_files = [re.compile(r"generated/ignored\.py$")]
+
+            self.runner.collect_all_files()
+
+        self.assertEqual(set(self.runner.all_files), {keep_file_path})
+
+    def test_analyze_dependencies_updates_metrics_violations_and_mermaid_edges(self):
+        source_element = CodeElement(
+            file=Path("views.py"),
+            name="view",
+            element_type="function",
+            line=1,
+            column=0,
+        )
+        target_element = CodeElement(
+            file=Path("models.py"),
+            name="Model",
+            element_type="class",
+            line=1,
+            column=0,
+        )
+        dependency = Dependency(
+            code_element=source_element,
+            depends_on_code_element=target_element,
+            dependency_type="function_call",
+            line=3,
+            column=4,
+        )
+        self.runner.code_element_to_layer = {
+            source_element: "views",
+            target_element: "models",
+        }
+        self.runner.rules = [DependencyRule("views", ["models"])]
+
+        def run_analyzer():
+            analyzer_class.call_args.kwargs["dependency_handler"](dependency)
+
+        with patch("deply.deply_runner.CodeAnalyzer") as analyzer_class:
+            analyzer_class.return_value.analyze.side_effect = run_analyzer
+            with patch.object(self.runner.mermaid_builder, "add_edge") as add_edge:
+                self.runner.analyze_dependencies()
+
+        self.assertEqual(self.runner.metrics["total_dependencies"], 1)
+        self.assertEqual(len(self.runner.violations), 1)
+        violation = next(iter(self.runner.violations))
+        self.assertEqual(violation.dependency, dependency)
+        add_edge.assert_called_once_with("views", "models", True)
 
     def test_collect_code_elements_parallel_branch(self):
         self.runner.layers_config = [{"name": "services_layer"}]

--- a/tests/test_external_import_rule.py
+++ b/tests/test_external_import_rule.py
@@ -31,7 +31,11 @@ class TestExternalImportRule(unittest.TestCase):
 
         self.assertIsNotNone(violation)
         self.assertEqual(violation.violation_type, ViolationType.DISALLOWED_EXTERNAL_IMPORT)
+        self.assertEqual(violation.file, self.element.file)
+        self.assertEqual(violation.element_name, "load_user")
+        self.assertEqual(violation.element_type, "function")
         self.assertEqual(violation.line, 1)
+        self.assertEqual(violation.column, 0)
         self.assertIn("external package 'requests'", violation.message)
 
     def test_unconfigured_import_passes(self):
@@ -166,6 +170,16 @@ class TestExternalImportRunner(unittest.TestCase):
             sorted(violation["line"] for violation in payload["violations"]),
             [1, 2],
         )
+        violations_by_line = {
+            violation["line"]: violation
+            for violation in payload["violations"]
+        }
+        self.assertEqual(violations_by_line[1]["element_name"], "load_user")
+        self.assertEqual(violations_by_line[1]["element_type"], "function")
+        self.assertEqual(violations_by_line[1]["column"], 0)
+        self.assertEqual(violations_by_line[2]["element_name"], "load_user")
+        self.assertEqual(violations_by_line[2]["element_type"], "function")
+        self.assertEqual(violations_by_line[2]["column"], 0)
 
     def test_runner_applies_line_suppression(self):
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/tests/test_false_dependency_path.py
+++ b/tests/test_false_dependency_path.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 import sys
 import tempfile
@@ -52,22 +51,24 @@ class TestFalseDependencyPath(unittest.TestCase):
 
     def run_deply(self, config_data) -> Tuple[int, str]:
         config_path = Path(self.test_dir) / 'deply.yaml'
+        config_for_run = {
+            **config_data,
+            "deply": {
+                **config_data["deply"],
+                "paths": [str(self.test_project_dir)],
+            },
+        }
         with config_path.open('w') as f:
-            yaml.dump(config_data, f)
+            yaml.dump(config_for_run, f)
 
-        old_cwd = os.getcwd()
-        os.chdir(self.test_dir)
-        try:
-            with captured_output() as (out, err):
-                exit_code = 0
-                try:
-                    sys.argv = ['main.py', 'analyze', '--config', str(config_path)]
-                    main()
-                except SystemExit as e:
-                    exit_code = e.code
-            output = out.getvalue()
-        finally:
-            os.chdir(old_cwd)
+        with captured_output() as (out, err):
+            exit_code = 0
+            try:
+                sys.argv = ['main.py', 'analyze', '--config', str(config_path)]
+                main()
+            except SystemExit as e:
+                exit_code = e.code
+        output = out.getvalue()
 
         return exit_code, output
 

--- a/tests/test_rule_factory.py
+++ b/tests/test_rule_factory.py
@@ -39,6 +39,35 @@ class TestRuleFactory(unittest.TestCase):
         self.assertEqual(len(rules), 1)
         self.assertIsInstance(rules[0], ExternalImportRule)
 
+    def test_create_rules_for_decorator_rules_preserves_layer_and_pattern(self):
+        rules = RuleFactory.create_rules(
+            {
+                "service_layer": {
+                    "enforce_class_decorator_usage": [
+                        {
+                            "type": "class_decorator_name_regex",
+                            "decorator_name_regex": r"^entity_.*$",
+                        }
+                    ],
+                    "enforce_function_decorator_usage": [
+                        {
+                            "type": "function_decorator_name_regex",
+                            "decorator_name_regex": r"^tracked_.*$",
+                        }
+                    ],
+                }
+            }
+        )
+
+        self.assertEqual(len(rules), 2)
+        class_decorator_rule, function_decorator_rule = rules
+        self.assertIsInstance(class_decorator_rule, ClassDecoratorUsageRule)
+        self.assertEqual(class_decorator_rule.layer_name, "service_layer")
+        self.assertEqual(class_decorator_rule.decorator_pattern.pattern, r"^entity_.*$")
+        self.assertIsInstance(function_decorator_rule, FunctionDecoratorUsageRule)
+        self.assertEqual(function_decorator_rule.layer_name, "service_layer")
+        self.assertEqual(function_decorator_rule.decorator_pattern.pattern, r"^tracked_.*$")
+
     def test_create_rule_from_config_for_bool_and_unknown_type(self):
         bool_rule = RuleFactory._create_rule_from_config(
             "service_layer",

--- a/tests/test_rule_violation_payloads.py
+++ b/tests/test_rule_violation_payloads.py
@@ -1,0 +1,200 @@
+import unittest
+from pathlib import Path
+
+from deply.models.code_element import CodeElement
+from deply.models.dependency import Dependency
+from deply.models.violation import Violation
+from deply.models.violation_types import ViolationType
+from deply.rules.bool_rule import BoolRule
+from deply.rules.class_decorator_rule import ClassDecoratorUsageRule
+from deply.rules.class_naming_rule import ClassNamingRule
+from deply.rules.dependency_rule import DependencyRule
+from deply.rules.external_import_rule import ExternalImportRule
+from deply.rules.function_decorator_rule import FunctionDecoratorUsageRule
+from deply.rules.function_naming_rule import FunctionNamingRule
+from deply.rules.inheritance_rule import InheritanceRule
+
+
+class TestRuleViolationPayloads(unittest.TestCase):
+    def _build_element(self, name: str, element_type: str, line: int = 7, column: int = 2) -> CodeElement:
+        return CodeElement(
+            file=Path("domain/service.py"),
+            name=name,
+            element_type=element_type,
+            line=line,
+            column=column,
+        )
+
+    def assert_payload(
+        self,
+        violation: Violation,
+        element: CodeElement,
+        violation_type: ViolationType,
+        line: int = 7,
+        column: int = 2,
+    ):
+        self.assertEqual(violation.file, element.file)
+        self.assertEqual(violation.element_name, element.name)
+        self.assertEqual(violation.element_type, element.element_type)
+        self.assertEqual(violation.line, line)
+        self.assertEqual(violation.column, column)
+        self.assertEqual(violation.violation_type, violation_type)
+
+    def test_naming_and_inheritance_rules_preserve_violation_payload(self):
+        class_element = self._build_element("domain.bad_class", "class")
+        function_element = self._build_element("domain.BadFunction", "function")
+
+        class_violation = ClassNamingRule("domain", r"^Good.*$").check_element("domain", class_element)
+        function_violation = FunctionNamingRule("domain", r"^good_.*$").check_element("domain", function_element)
+        inheritance_violation = InheritanceRule("domain", "BaseModel").check_element("domain", class_element)
+
+        self.assertIsNotNone(class_violation)
+        self.assert_payload(class_violation, class_element, ViolationType.CLASS_NAMING)
+        self.assertIsNotNone(function_violation)
+        self.assert_payload(function_violation, function_element, ViolationType.FUNCTION_NAMING)
+        self.assertEqual(
+            function_violation.message,
+            "Function 'domain.BadFunction' does not match naming pattern '^good_.*$'.",
+        )
+        self.assertIsNotNone(inheritance_violation)
+        self.assert_payload(inheritance_violation, class_element, ViolationType.INHERITANCE)
+
+    def test_naming_and_inheritance_rules_handle_qualified_names(self):
+        class_element = self._build_element("domain.GoodClass", "class")
+        function_element = self._build_element("domain.good_function", "function")
+        exact_inheritance_element = CodeElement(
+            file=Path("domain/model.py"),
+            name="User",
+            element_type="class",
+            line=1,
+            column=0,
+            inherits=("BaseModel",),
+        )
+        qualified_inheritance_element = CodeElement(
+            file=Path("domain/model.py"),
+            name="Admin",
+            element_type="class",
+            line=5,
+            column=0,
+            inherits=("framework.BaseModel",),
+        )
+
+        self.assertIsNone(ClassNamingRule("domain", r"^GoodClass$").check_element("domain", class_element))
+        self.assertIsNone(FunctionNamingRule("domain", r"^good_function$").check_element("domain", function_element))
+        self.assertIsNone(InheritanceRule("domain", "BaseModel").check_element("domain", exact_inheritance_element))
+        self.assertIsNone(InheritanceRule("domain", "BaseModel").check_element("domain", qualified_inheritance_element))
+
+    def test_rules_do_not_apply_to_wrong_layer_or_element_type(self):
+        class_element = self._build_element("bad_class", "class")
+        function_element = self._build_element("BadFunction", "function")
+
+        self.assertIsNone(ClassNamingRule("domain", r"^Good.*$").check_element("other", class_element))
+        self.assertIsNone(ClassNamingRule("domain", r"^Good.*$").check_element("domain", function_element))
+        self.assertIsNone(FunctionNamingRule("domain", r"^good_.*$").check_element("other", function_element))
+        self.assertIsNone(FunctionNamingRule("domain", r"^good_.*$").check_element("domain", class_element))
+        self.assertIsNone(InheritanceRule("domain", "BaseModel").check_element("other", class_element))
+        self.assertIsNone(InheritanceRule("domain", "BaseModel").check_element("domain", function_element))
+
+    def test_dependency_and_external_import_rules_preserve_violation_payload(self):
+        source_element = self._build_element("load_user", "function", line=12, column=4)
+        target_element = CodeElement(
+            file=Path("domain/model.py"),
+            name="User",
+            element_type="class",
+            line=1,
+            column=0,
+        )
+        dependency = Dependency(
+            code_element=source_element,
+            depends_on_code_element=target_element,
+            dependency_type="function_call",
+            line=14,
+            column=8,
+        )
+
+        dependency_violation = DependencyRule("service", ["domain"]).check("service", "domain", dependency)
+        external_violation = ExternalImportRule("service", ["requests"]).check_external_import(
+            "service",
+            source_element,
+            "requests.sessions",
+            3,
+            0,
+        )
+
+        self.assertIsNotNone(dependency_violation)
+        self.assert_payload(dependency_violation, source_element, ViolationType.DISALLOWED_DEPENDENCY, 14, 8)
+        self.assertEqual(dependency_violation.dependency, dependency)
+        self.assertIsNotNone(external_violation)
+        self.assert_payload(external_violation, source_element, ViolationType.DISALLOWED_EXTERNAL_IMPORT, 3, 0)
+
+    def test_decorator_and_bool_rules_preserve_violation_payload(self):
+        function_element = CodeElement(
+            file=Path("service.py"),
+            name="load_user",
+            element_type="function",
+            line=5,
+            column=4,
+            decorators=("plain_decorator",),
+        )
+        class_element = CodeElement(
+            file=Path("service.py"),
+            name="Service",
+            element_type="class",
+            line=9,
+            column=0,
+            decorators=("plain_decorator",),
+        )
+
+        decorator_violation = FunctionDecoratorUsageRule("service", r"^tracked_.*$").check_element(
+            "service",
+            function_element,
+        )
+        class_decorator_violation = ClassDecoratorUsageRule("service", r"^entity_.*$").check_element(
+            "service",
+            class_element,
+        )
+        bool_violation = BoolRule(
+            "service",
+            {
+                "must_not": [
+                    {
+                        "type": "function_name_regex",
+                        "function_name_regex": "^load_.*$",
+                    }
+                ]
+            },
+        ).check_element("service", function_element)
+
+        self.assertIsNotNone(decorator_violation)
+        self.assert_payload(decorator_violation, function_element, ViolationType.FUNCTION_DECORATOR_USAGE, 5, 4)
+        self.assertIsNotNone(class_decorator_violation)
+        self.assert_payload(class_decorator_violation, class_element, ViolationType.CLASS_DECORATOR_USAGE, 9, 0)
+        self.assertIsNotNone(bool_violation)
+        self.assert_payload(bool_violation, function_element, ViolationType.BOOL_RULE, 5, 4)
+
+    def test_decorator_rules_ignore_wrong_layer_or_element_type_even_without_matching_decorator(self):
+        function_element = CodeElement(
+            file=Path("service.py"),
+            name="load_user",
+            element_type="function",
+            line=5,
+            column=4,
+            decorators=("plain_decorator",),
+        )
+        class_element = CodeElement(
+            file=Path("service.py"),
+            name="Service",
+            element_type="class",
+            line=9,
+            column=0,
+            decorators=("plain_decorator",),
+        )
+
+        self.assertIsNone(FunctionDecoratorUsageRule("service", r"^tracked_.*$").check_element("other", function_element))
+        self.assertIsNone(FunctionDecoratorUsageRule("service", r"^tracked_.*$").check_element("service", class_element))
+        self.assertIsNone(ClassDecoratorUsageRule("service", r"^entity_.*$").check_element("other", class_element))
+        self.assertIsNone(ClassDecoratorUsageRule("service", r"^entity_.*$").check_element("service", function_element))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,7 +1,6 @@
 import unittest
 import tempfile
 import shutil
-import os
 from pathlib import Path
 import sys
 import yaml
@@ -36,22 +35,24 @@ class TestRules(unittest.TestCase):
     def run_deply(self, config_data):
         # Write config
         config_yaml = Path(self.test_dir) / 'deply.yaml'
+        config_for_run = {
+            **config_data,
+            "deply": {
+                **config_data["deply"],
+                "paths": [str(self.test_project_dir)],
+            },
+        }
         with config_yaml.open('w') as f:
-            yaml.dump(config_data, f)
+            yaml.dump(config_for_run, f)
 
-        old_cwd = os.getcwd()
-        os.chdir(self.test_dir)
-        try:
-            with captured_output() as (out, err):
-                exit_code = 0
-                try:
-                    sys.argv = ['main.py', 'analyze', '--config', str(config_yaml)]
-                    main()
-                except SystemExit as e:
-                    exit_code = e.code
-            output = out.getvalue()
-        finally:
-            os.chdir(old_cwd)
+        with captured_output() as (out, err):
+            exit_code = 0
+            try:
+                sys.argv = ['main.py', 'analyze', '--config', str(config_yaml)]
+                main()
+            except SystemExit as e:
+                exit_code = e.code
+        output = out.getvalue()
 
         return exit_code, output
 


### PR DESCRIPTION
## Summary
- Remove temp-cwd coupling from analyzer-style tests so mutmut stats can resolve source paths correctly.
- Add focused coverage for important survived mutants in rule payloads, BoolRule any_of behavior, DependencyVisitor flows, DeplyRunner orchestration, and external import JSON output.
- Keep production code and mutmut config unchanged.

## Validation
- `./.venv/bin/python -m unittest tests.test_bool_rule tests.test_rule_factory tests.test_rule_violation_payloads tests.test_dependency_visitor tests.test_deply_runner tests.test_external_import_rule`
- `make check`
- `rm -rf mutants && make mutation`

## Mutation Result
- Before: `killed=877`, `survived=249`, `suspicious=0`
- After: `killed=983`, `survived=143`, `suspicious=0`

Remaining survivors are mostly low-value logging/init/default fallback mutants in runner/visitor/factory code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage across rule evaluation, dependency tracking, runner behavior, and violation payload details.
  * Added checks for boolean rules, decorator rules, inheritance, external imports, and dependency reporting.
  * Improved CLI test setup to use absolute project paths, making test runs more reliable without changing the working directory.
  * Added validations for exclusion patterns, metrics updates, and generated diagram edges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->