### PR TITLE
Add config validation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ When you have this file, you can analyse your code by running the analyze comman
 deply analyze
 
 # which is equivalent to
-deply analyze --config-file=deply.yaml
+deply analyze --config=deply.yaml
 ```
 
 In order to run Deply you need at least Python 3.8.
@@ -84,6 +84,9 @@ deply analyze
 # With a specific config file
 deply analyze --config=custom_config.yaml
 
+# Validate configuration only
+deply validate --config=custom_config.yaml
+
 # Generate a Mermaid diagram
 deply analyze --mermaid
 
@@ -100,6 +103,7 @@ deply --help
 - **Extensible and Configurable**: Customize layers and rules for any Python project setup.
 - **Mermaid Diagrams**: Visualize your architecture and dependencies with Mermaid diagrams.
 - **Error Suppression**: Suppress specific rule violations with inline comments.
+- **Config Validation**: Validate `deply.yaml` without running project analysis.
 
 ## Error Suppression
 
@@ -145,7 +149,7 @@ A plan to evolve Deply into a must-have architectural guardian for Python projec
   🔲 Interactive config setup (`deply init` wizard)  
   🔲 GitHub Actions/GitLab CI templates  
   ✅ `# deply:ignore` suppression comments  
-  🔲 Config validation command (`deply validate`)  
+  ✅ Config validation command (`deply validate`)
   ✅ Parallel file analysis  
   ✅ Custom collectors system  
   🔲 Dependency graph caching  

--- a/deply/config_validator.py
+++ b/deply/config_validator.py
@@ -1,0 +1,326 @@
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Set
+
+from deply.collectors.base_collector import BaseCollector
+
+
+class ConfigValidator:
+    TOP_LEVEL_KEYS = {"paths", "exclude_files", "layers", "ruleset"}
+    COLLECTOR_TYPES = {
+        "file_regex",
+        "class_inherits",
+        "class_name_regex",
+        "function_name_regex",
+        "directory",
+        "decorator_usage",
+        "bool",
+        "custom",
+    }
+    RULE_KEYS = {
+        "disallow_layer_dependencies",
+        "disallow_external_imports",
+        "enforce_class_naming",
+        "enforce_function_naming",
+        "enforce_class_decorator_usage",
+        "enforce_function_decorator_usage",
+        "enforce_inheritance",
+    }
+    RULE_TYPES = {
+        "class_name_regex",
+        "function_name_regex",
+        "class_decorator_name_regex",
+        "function_decorator_name_regex",
+        "class_inherits",
+        "bool",
+    }
+
+    def __init__(self, config_path: Path):
+        self.config_path = config_path
+
+    def validate(self, config: Dict[str, Any]) -> List[str]:
+        errors: List[str] = []
+        if not isinstance(config, dict):
+            return ["root: must be a mapping"]
+
+        self._validate_known_keys(config, "", self.TOP_LEVEL_KEYS, errors)  # pragma: no mutate
+        self._validate_paths(config.get("paths"), errors)
+        self._validate_exclude_files(config.get("exclude_files"), errors)
+
+        layer_names = self._validate_layers(config.get("layers"), errors)
+        self._validate_ruleset(config.get("ruleset"), layer_names, errors)
+        return errors
+
+    def _validate_known_keys(self, config: Dict[str, Any], path: str, known_keys: Set[str], errors: List[str]) -> None:
+        for key in config:
+            if key not in known_keys:
+                errors.append(f"{self._join(path, key)}: unknown key")
+
+    def _validate_paths(self, paths: Any, errors: List[str]) -> None:
+        if not self._is_string_list(paths):
+            errors.append("paths: must be a non-empty list of strings")
+            return
+
+        for index, path in enumerate(paths):
+            if not Path(path).exists():
+                errors.append(f"paths[{index}]: path does not exist: {path}")
+
+    def _validate_exclude_files(self, exclude_files: Any, errors: List[str]) -> None:
+        if not isinstance(exclude_files, list) or not all(isinstance(pattern, str) for pattern in exclude_files):
+            errors.append("exclude_files: must be a list of strings")
+            return
+
+        for index, pattern in enumerate(exclude_files):
+            self._validate_regex(pattern, f"exclude_files[{index}]", errors)
+
+    def _validate_layers(self, layers: Any, errors: List[str]) -> Set[str]:
+        if not isinstance(layers, list):
+            errors.append("layers: must be a non-empty list")
+            return set()
+        if not layers:
+            errors.append("layers: must contain at least one layer")
+            return set()
+
+        layer_names: Set[str] = set()
+        for index, layer_config in enumerate(layers):
+            layer_path = f"layers[{index}]"
+            if not isinstance(layer_config, dict):
+                errors.append(f"{layer_path}: must be a mapping")
+                continue
+
+            layer_name = layer_config.get("name")
+            if not isinstance(layer_name, str) or not layer_name:
+                errors.append(f"{layer_path}.name: required")
+            elif layer_name in layer_names:
+                errors.append(f"{layer_path}.name: duplicate layer name: {layer_name}")
+            else:
+                layer_names.add(layer_name)
+
+            collectors = layer_config.get("collectors")
+            if not isinstance(collectors, list):
+                errors.append(f"{layer_path}.collectors: must be a non-empty list")
+                continue
+            if not collectors:
+                errors.append(f"{layer_path}.collectors: must contain at least one collector")
+                continue
+
+            for collector_index, collector_config in enumerate(collectors):
+                self._validate_collector(
+                    collector_config,
+                    f"{layer_path}.collectors[{collector_index}]",
+                    errors,
+                )
+
+        return layer_names
+
+    def _validate_collector(self, collector_config: Any, path: str, errors: List[str]) -> None:
+        if not isinstance(collector_config, dict):
+            errors.append(f"{path}: must be a mapping")
+            return
+
+        collector_type = collector_config.get("type")
+        if not isinstance(collector_type, str) or not collector_type:
+            errors.append(f"{path}.type: required")
+            return
+        if collector_type not in self.COLLECTOR_TYPES:
+            errors.append(f"{path}.type: unknown collector type: {collector_type}")
+            return
+
+        if collector_type == "file_regex":
+            self._validate_required_regex(collector_config, "regex", path, errors)
+        elif collector_type == "class_inherits":
+            self._validate_required_string(collector_config, "base_class", path, errors)
+        elif collector_type == "class_name_regex":
+            self._validate_required_regex(collector_config, "class_name_regex", path, errors)
+        elif collector_type == "function_name_regex":
+            self._validate_required_regex(collector_config, "function_name_regex", path, errors)
+        elif collector_type == "directory":
+            self._validate_required_string_list(collector_config, "directories", path, errors)
+        elif collector_type == "decorator_usage":
+            self._validate_decorator_collector(collector_config, path, errors)
+        elif collector_type == "bool":
+            self._validate_bool_group(collector_config, path, self._validate_collector, errors)
+        elif collector_type == "custom":
+            self._validate_custom_collector(collector_config, path, errors)
+
+        exclude_files_regex = collector_config.get("exclude_files_regex")
+        if isinstance(exclude_files_regex, str) and exclude_files_regex:
+            self._validate_regex(exclude_files_regex, f"{path}.exclude_files_regex", errors)
+        elif exclude_files_regex is not None:
+            errors.append(f"{path}.exclude_files_regex: must be a string")
+
+    def _validate_decorator_collector(self, collector_config: Dict[str, Any], path: str, errors: List[str]) -> None:
+        decorator_name = collector_config.get("decorator_name")
+        decorator_regex = collector_config.get("decorator_regex")
+        if not decorator_name and not decorator_regex:
+            errors.append(f"{path}: decorator_name or decorator_regex required")
+            return
+        if decorator_name is not None and not isinstance(decorator_name, str):
+            errors.append(f"{path}.decorator_name: must be a string")
+        if decorator_regex is not None:
+            if isinstance(decorator_regex, str):
+                self._validate_regex(decorator_regex, f"{path}.decorator_regex", errors)
+            else:
+                errors.append(f"{path}.decorator_regex: must be a string")
+
+    def _validate_custom_collector(self, collector_config: Dict[str, Any], path: str, errors: List[str]) -> None:
+        class_path = collector_config.get("class")
+        if not isinstance(class_path, str) or not class_path:
+            errors.append(f"{path}.class: required")
+            return
+
+        try:
+            module_name, class_name = class_path.rsplit(".", 1)
+        except ValueError:
+            errors.append(f"{path}.class: invalid class path format: {class_path}")
+            return
+
+        try:
+            module = __import__(module_name, fromlist=[class_name])
+        except ImportError as exception:
+            errors.append(f"{path}.class: failed to import module '{module_name}': {exception}")
+            return
+
+        collector_class = getattr(module, class_name, None)
+        if collector_class is None:
+            errors.append(f"{path}.class: class '{class_name}' not found in {module_name}")
+            return
+        if not isinstance(collector_class, type) or not issubclass(collector_class, BaseCollector):
+            errors.append(f"{path}.class: class '{class_name}' must inherit from BaseCollector")
+
+    def _validate_ruleset(self, ruleset: Any, layer_names: Set[str], errors: List[str]) -> None:
+        if not isinstance(ruleset, dict):
+            errors.append("ruleset: must be a mapping")
+            return
+
+        for layer_name, layer_rules in ruleset.items():
+            layer_path = f"ruleset.{layer_name}"
+            if not isinstance(layer_name, str) or not layer_name:
+                errors.append("ruleset: layer names must be non-empty strings")
+                continue
+            if layer_name not in layer_names:
+                errors.append(f"{layer_path}: unknown layer: {layer_name}")
+            if not isinstance(layer_rules, dict):
+                errors.append(f"{layer_path}: must be a mapping")
+                continue
+
+            for rule_key, rule_config in layer_rules.items():
+                if rule_key not in self.RULE_KEYS:
+                    errors.append(f"{layer_path}.{rule_key}: unknown rule key")
+                    continue
+                if rule_key == "disallow_layer_dependencies":
+                    self._validate_layer_references(rule_config, f"{layer_path}.{rule_key}", layer_names, errors)
+                elif rule_key == "disallow_external_imports":
+                    self._validate_string_list(rule_config, f"{layer_path}.{rule_key}", errors)
+                else:
+                    self._validate_rule_list(rule_config, f"{layer_path}.{rule_key}", errors)
+
+    def _validate_rule_list(self, rule_configs: Any, path: str, errors: List[str]) -> None:
+        if not isinstance(rule_configs, list):
+            errors.append(f"{path}: must be a list")
+            return
+
+        for index, rule_config in enumerate(rule_configs):
+            self._validate_rule(rule_config, f"{path}[{index}]", errors)
+
+    def _validate_rule(self, rule_config: Any, path: str, errors: List[str]) -> None:
+        if not isinstance(rule_config, dict):
+            errors.append(f"{path}: must be a mapping")
+            return
+
+        rule_type = rule_config.get("type")
+        if not isinstance(rule_type, str) or not rule_type:
+            errors.append(f"{path}.type: required")
+            return
+        if rule_type not in self.RULE_TYPES:
+            errors.append(f"{path}.type: unknown rule type: {rule_type}")
+            return
+
+        if rule_type == "class_name_regex":
+            self._validate_required_regex(rule_config, "class_name_regex", path, errors)
+        elif rule_type == "function_name_regex":
+            self._validate_required_regex(rule_config, "function_name_regex", path, errors)
+        elif rule_type in {"class_decorator_name_regex", "function_decorator_name_regex"}:
+            self._validate_required_regex(rule_config, "decorator_name_regex", path, errors)
+        elif rule_type == "class_inherits":
+            self._validate_required_string(rule_config, "base_class", path, errors)
+        elif rule_type == "bool":
+            self._validate_bool_group(rule_config, path, self._validate_rule, errors)
+
+    def _validate_layer_references(self, values: Any, path: str, layer_names: Set[str], errors: List[str]) -> None:
+        if not self._validate_string_list(values, path, errors):
+            return
+
+        for index, layer_name in enumerate(values):
+            if layer_name not in layer_names:
+                errors.append(f"{path}[{index}]: unknown layer: {layer_name}")
+
+    def _validate_bool_group(self, config: Dict[str, Any], path: str, validator: Any, errors: List[str]) -> None:
+        has_collectors = False  # pragma: no mutate
+        for key in ("must", "any_of", "must_not"):
+            values = config.get(key, [])
+            if not isinstance(values, list):
+                errors.append(f"{path}.{key}: must be a list")
+                continue
+            if values:
+                has_collectors = True
+            for index, value in enumerate(values):
+                validator(value, f"{path}.{key}[{index}]", errors)
+
+        if not has_collectors:
+            errors.append(f"{path}: one of must, any_of, or must_not must contain collectors")
+
+    def _validate_required_regex(
+            self,
+            config: Dict[str, Any],
+            key: str,
+            path: str,
+            errors: List[str],
+    ) -> None:
+        value = config.get(key)
+        if not isinstance(value, str) or not value:
+            errors.append(f"{path}.{key}: required")
+            return
+        self._validate_regex(value, f"{path}.{key}", errors)
+
+    def _validate_required_string(
+            self,
+            config: Dict[str, Any],
+            key: str,
+            path: str,
+            errors: List[str],
+    ) -> None:
+        value = config.get(key)
+        if not isinstance(value, str) or not value:
+            errors.append(f"{path}.{key}: required")
+
+    def _validate_required_string_list(
+            self,
+            config: Dict[str, Any],
+            key: str,
+            path: str,
+            errors: List[str],
+    ) -> None:
+        value = config.get(key)
+        if not self._is_string_list(value):
+            errors.append(f"{path}.{key}: must be a non-empty list of strings")
+
+    def _validate_string_list(self, values: Any, path: str, errors: List[str]) -> bool:
+        if not isinstance(values, list) or not all(isinstance(value, str) for value in values):
+            errors.append(f"{path}: must be a list of strings")
+            return False
+        return True
+
+    def _validate_regex(self, pattern: str, path: str, errors: List[str]) -> None:
+        try:
+            re.compile(pattern)
+        except re.error as exception:
+            errors.append(f"{path}: invalid regex: {exception}")
+
+    def _is_string_list(self, values: Any) -> bool:
+        return isinstance(values, list) and bool(values) and all(isinstance(value, str) for value in values)
+
+    def _join(self, path: str, key: str) -> str:
+        if not path:
+            return key
+        return f"{path}.{key}"

--- a/deply/main.py
+++ b/deply/main.py
@@ -1,12 +1,35 @@
 import argparse
 import logging
 import sys
+from pathlib import Path
 
+import yaml
 from deply import __version__
+from deply.config_parser import ConfigParser
+from deply.config_validator import ConfigValidator
 from deply.deply_runner import DeplyRunner
 
 
+def validate_configuration(config_path: str) -> bool:
+    configuration_path = Path(config_path)
+    try:
+        config = ConfigParser(configuration_path).parse()
+        errors = ConfigValidator(configuration_path).validate(config)
+    except (OSError, ValueError, yaml.YAMLError) as exception:
+        errors = [str(exception)]
+
+    if not errors:
+        print(f"Configuration is valid: {configuration_path}")
+        return True
+
+    print("Invalid deply configuration:", file=sys.stderr)
+    for error in errors:
+        print(f"- {error}", file=sys.stderr)
+    return False
+
+
 def main():
+    # pragma: no mutate start
     parser = argparse.ArgumentParser(prog="deply", description='Deply - An architecture analysis tool')
     parser.add_argument('-V', '--version', action='store_true', help='Show the version number and exit')
     parser.add_argument('-v', '--verbose', action='count', default=1, help='Increase output verbosity')
@@ -40,6 +63,9 @@ def main():
              "Optionally specify the number of processes to use. "
              "If no number is provided, all available CPU cores will be used."
     )
+    parser_validate = subparsers.add_parser('validate', help='Validate the configuration file')
+    parser_validate.add_argument('--config', type=str, default="deply.yaml", help="Path to the configuration YAML file")
+    # pragma: no mutate end
 
     args = parser.parse_args()
 
@@ -48,7 +74,7 @@ def main():
         sys.exit(0)
 
     if args.command is None:
-        args = parser.parse_args(['analyze'] + sys.argv[1:])
+        args = parser.parse_args(['analyze'] + sys.argv[1:])  # pragma: no mutate
 
     log_level = logging.WARNING
     if args.verbose == 1:
@@ -58,11 +84,14 @@ def main():
 
     logging.basicConfig(
         level=log_level,
-        format='[%(asctime)s] [%(levelname)s] %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S'
+        format='[%(asctime)s] [%(levelname)s] %(message)s',  # pragma: no mutate
+        datefmt='%Y-%m-%d %H:%M:%S'  # pragma: no mutate
     )
 
-    logging.info("Starting Deply analysis...")
+    if args.command == "validate":
+        sys.exit(0 if validate_configuration(args.config) else 1)
+
+    logging.getLogger(__name__).info("Starting Deply analysis...")  # pragma: no mutate
     runner = DeplyRunner(args)
     if runner.run():
         sys.exit(0)

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -18,6 +18,14 @@ The main command for analyzing your project:
 deply analyze
 ```
 
+### Validate Command
+
+Validate your configuration without analyzing project files:
+
+```bash
+deply validate
+```
+
 ### Help Command
 
 Display help information:
@@ -31,11 +39,15 @@ deply --help
 ### Analyze Command Options
 
 - `--config`: Path to the configuration YAML file (default: `deply.yaml`)
-- `--report-format`: Format of the output report (choices: `text`, `json`, `html`, default: `text`)
+- `--report-format`: Format of the output report (choices: `text`, `json`, `github-actions`, default: `text`)
 - `--output`: Output file for the report (if not specified, prints to console)
 - `--mermaid`: Generates a Mermaid diagram of layer dependencies
 - `--max-violations`: Maximum number of allowed violations before failing (default: 0)
 - `--parallel`: Enable parallel processing of code elements
+
+### Validate Command Options
+
+- `--config`: Path to the configuration YAML file (default: `deply.yaml`)
 
 ## Examples
 
@@ -51,10 +63,16 @@ deply analyze
 deply analyze --config=custom_config.yaml
 ```
 
-### Generate HTML Report
+### Validate Configuration
 
 ```bash
-deply analyze --report-format=html --output=report.html
+deply validate --config=custom_config.yaml
+```
+
+### Generate GitHub Actions Report
+
+```bash
+deply analyze --report-format=github-actions
 ```
 
 ### Generate Mermaid Diagram
@@ -100,10 +118,6 @@ The JSON format provides structured data that can be easily parsed by other tool
   ]
 }
 ```
-
-### HTML Format
-
-The HTML format provides a formatted report that can be viewed in a web browser, with syntax highlighting and better readability.
 
 For more information about:
 - Mermaid diagrams, see the [Mermaid Diagrams](mermaid.html) documentation

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -74,6 +74,16 @@ ruleset:
 
 Collectors define how code elements are collected into layers. See the [Collectors Reference](collectors.html) for detailed information about each collector type.
 
+## Validate Configuration
+
+Run `deply validate` to check configuration syntax and schema without analyzing project files:
+
+```bash
+deply validate --config=deply.yaml
+```
+
+The command checks YAML parsing, supported top-level keys, path existence, regex validity, layer names, collector settings, rule settings, and references between rules and layers. It exits with status `0` when the configuration is valid and `1` when validation errors are found.
+
 ## Advanced Configuration Examples
 
 ### Complex Layer Definition

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,9 @@ show_error_codes = true
 pretty = true
 
 [tool.mutmut]
-paths_to_mutate = [
+source_paths = [
+    "deply/main.py",
+    "deply/config_validator.py",
     "deply/deply_runner.py",
     "deply/utils/dependency_visitor.py",
     "deply/rules/",

--- a/tests/test_config_validator.py
+++ b/tests/test_config_validator.py
@@ -1,0 +1,577 @@
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+from deply.collectors.base_collector import BaseCollector
+from deply.config_validator import ConfigValidator
+
+
+class DummyCustomCollector(BaseCollector):
+    def __init__(self, config: dict):
+        self.config = config
+
+    def match_in_file(self, file_ast, file_path) -> set:
+        return set()
+
+
+class TestConfigValidator(unittest.TestCase):
+    def _validate(self, config):
+        return ConfigValidator(Path("deply.yaml")).validate(config)
+
+    def test_preserves_config_path(self):
+        config_path = Path("custom.yaml")
+
+        validator = ConfigValidator(config_path)
+
+        self.assertEqual(validator.config_path, config_path)
+
+    def test_reports_non_mapping_root(self):
+        errors = self._validate([])
+
+        self.assertEqual(errors, ["root: must be a mapping"])
+
+    def test_accepts_valid_configuration(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            project_path = Path(temporary_directory)
+            config = {
+                "paths": [str(project_path)],
+                "exclude_files": [r".*\.venv/.*"],
+                "layers": [
+                    {
+                        "name": "domain",
+                        "collectors": [
+                            {
+                                "type": "class_name_regex",
+                                "class_name_regex": r".*Entity$",
+                            }
+                        ],
+                    },
+                    {
+                        "name": "app",
+                        "collectors": [
+                            {
+                                "type": "bool",
+                                "must": [
+                                    {
+                                        "type": "directory",
+                                        "directories": ["app"],
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                ],
+                "ruleset": {
+                    "app": {
+                        "disallow_layer_dependencies": ["domain"],
+                        "disallow_external_imports": ["django"],
+                        "enforce_function_decorator_usage": [
+                            {
+                                "type": "function_decorator_name_regex",
+                                "decorator_name_regex": r"^transactional$",
+                            }
+                        ],
+                    }
+                },
+            }
+
+            errors = ConfigValidator(project_path / "deply.yaml").validate(config)
+
+        self.assertEqual(errors, [])
+
+    def test_reports_empty_layers(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            project_path = Path(temporary_directory)
+            config = {
+                "paths": [str(project_path)],
+                "exclude_files": [],
+                "layers": [],
+                "ruleset": {},
+            }
+
+            errors = self._validate(config)
+
+        self.assertEqual(errors, ["layers: must contain at least one layer"])
+
+    def test_reports_top_level_and_regex_errors(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            project_path = Path(temporary_directory)
+            config = {
+                "paths": [str(project_path)],
+                "exclude_files": ["["],
+                "layers": [
+                    {
+                        "name": "domain",
+                        "collectors": [
+                            {
+                                "type": "class_name_regex",
+                                "class_name_regex": "[",
+                            }
+                        ],
+                    }
+                ],
+                "ruleset": {},
+                "unexpected": True,
+            }
+
+            errors = ConfigValidator(project_path / "deply.yaml").validate(config)
+
+        self.assertIn("unexpected: unknown key", errors)
+        self.assertTrue(any(error.startswith("exclude_files[0]: invalid regex") for error in errors))
+        self.assertTrue(
+            any(error.startswith("layers[0].collectors[0].class_name_regex: invalid regex") for error in errors)
+        )
+
+    def test_reports_duplicate_layers_and_unknown_collector(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            project_path = Path(temporary_directory)
+            config = {
+                "paths": [str(project_path)],
+                "exclude_files": [],
+                "layers": [
+                    {
+                        "name": "domain",
+                        "collectors": [
+                            {
+                                "type": "unknown",
+                            }
+                        ],
+                    },
+                    {
+                        "name": "domain",
+                        "collectors": [
+                            {
+                                "type": "file_regex",
+                            }
+                        ],
+                    },
+                ],
+                "ruleset": {},
+            }
+
+            errors = ConfigValidator(project_path / "deply.yaml").validate(config)
+
+        self.assertIn("layers[0].collectors[0].type: unknown collector type: unknown", errors)
+        self.assertIn("layers[1].name: duplicate layer name: domain", errors)
+        self.assertIn("layers[1].collectors[0].regex: required", errors)
+
+    def test_reports_basic_shape_errors(self):
+        config = {
+            "paths": ("not-list",),
+            "exclude_files": "not-list",
+            "layers": [
+                "not-mapping",
+                {
+                    "name": 123,
+                    "collectors": "not-list",
+                },
+                {
+                    "name": "empty",
+                    "collectors": [],
+                },
+                {
+                    "name": "after_empty",
+                    "collectors": [
+                        {
+                            "type": "unknown",
+                        }
+                    ],
+                },
+            ],
+            "ruleset": [],
+        }
+
+        errors = self._validate(config)
+
+        self.assertIn("paths: must be a non-empty list of strings", errors)
+        self.assertIn("exclude_files: must be a list of strings", errors)
+        self.assertIn("layers[0]: must be a mapping", errors)
+        self.assertIn("layers[1].name: required", errors)
+        self.assertIn("layers[1].collectors: must be a non-empty list", errors)
+        self.assertIn("layers[2].collectors: must contain at least one collector", errors)
+        self.assertIn("layers[3].collectors[0].type: unknown collector type: unknown", errors)
+        self.assertIn("ruleset: must be a mapping", errors)
+
+    def test_reports_collector_required_field_errors(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            project_path = Path(temporary_directory)
+            config = {
+                "paths": [str(project_path)],
+                "exclude_files": [],
+                "layers": [
+                    {
+                        "name": "domain",
+                        "collectors": [
+                            {
+                                "type": "file_regex",
+                            },
+                            {
+                                "type": "class_inherits",
+                            },
+                            {
+                                "type": "function_name_regex",
+                            },
+                            {
+                                "type": "directory",
+                            },
+                            {
+                                "type": "custom",
+                            },
+                            {
+                                "type": "class_name_regex",
+                                "class_name_regex": r".*Entity$",
+                                "exclude_files_regex": "[",
+                            },
+                            {
+                                "type": 123,
+                            },
+                            {
+                                "type": "function_name_regex",
+                                "function_name_regex": ".*",
+                                "exclude_files_regex": 123,
+                            },
+                        ],
+                    }
+                ],
+                "ruleset": {},
+            }
+
+            errors = self._validate(config)
+
+        self.assertIn("layers[0].collectors[0].regex: required", errors)
+        self.assertIn("layers[0].collectors[1].base_class: required", errors)
+        self.assertIn("layers[0].collectors[2].function_name_regex: required", errors)
+        self.assertIn("layers[0].collectors[3].directories: must be a non-empty list of strings", errors)
+        self.assertIn("layers[0].collectors[4].class: required", errors)
+        self.assertTrue(
+            any(
+                error.startswith("layers[0].collectors[5].exclude_files_regex: invalid regex")
+                for error in errors
+            )
+        )
+        self.assertIn("layers[0].collectors[6].type: required", errors)
+        self.assertIn("layers[0].collectors[7].exclude_files_regex: must be a string", errors)
+
+    def test_accepts_valid_custom_collector(self):
+        module_name = "dummy_validator_collectors"
+        dummy_module = types.ModuleType(module_name)
+        setattr(dummy_module, "DummyCustomCollector", DummyCustomCollector)
+        sys.modules[module_name] = dummy_module
+        try:
+            with tempfile.TemporaryDirectory() as temporary_directory:
+                project_path = Path(temporary_directory)
+                config = {
+                    "paths": [str(project_path)],
+                    "exclude_files": [],
+                    "layers": [
+                        {
+                            "name": "domain",
+                            "collectors": [
+                                {
+                                    "type": "custom",
+                                    "class": f"{module_name}.DummyCustomCollector",
+                                }
+                            ],
+                        }
+                    ],
+                    "ruleset": {},
+                }
+
+                errors = self._validate(config)
+        finally:
+            del sys.modules[module_name]
+
+        self.assertEqual(errors, [])
+
+    def test_accepts_decorator_collector_name_or_regex_and_reports_bad_values(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            project_path = Path(temporary_directory)
+            config = {
+                "paths": [str(project_path)],
+                "exclude_files": [],
+                "layers": [
+                    {
+                        "name": "domain",
+                        "collectors": [
+                            {
+                                "type": "decorator_usage",
+                                "decorator_name": "entity",
+                            },
+                            {
+                                "type": "decorator_usage",
+                                "decorator_regex": r"^entity_",
+                            },
+                            {
+                                "type": "decorator_usage",
+                                "decorator_name": 123,
+                                "decorator_regex": "[",
+                            },
+                        ],
+                    }
+                ],
+                "ruleset": {},
+            }
+
+            errors = self._validate(config)
+
+        self.assertNotIn("layers[0].collectors[0]: decorator_name or decorator_regex required", errors)
+        self.assertNotIn("layers[0].collectors[0].decorator_name: must be a string", errors)
+        self.assertNotIn("layers[0].collectors[1]: decorator_name or decorator_regex required", errors)
+        self.assertIn("layers[0].collectors[2].decorator_name: must be a string", errors)
+        self.assertTrue(
+            any(error.startswith("layers[0].collectors[2].decorator_regex: invalid regex") for error in errors)
+        )
+
+    def test_reports_nested_bool_collector_errors(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            project_path = Path(temporary_directory)
+            config = {
+                "paths": [str(project_path)],
+                "exclude_files": [],
+                "layers": [
+                    {
+                        "name": "domain",
+                        "collectors": [
+                            {
+                                "type": "bool",
+                                "must": [
+                                    {
+                                        "type": "decorator_usage",
+                                    }
+                                ],
+                            },
+                            {
+                                "type": "bool",
+                                "must": [],
+                            },
+                        ],
+                    }
+                ],
+                "ruleset": {},
+            }
+
+            errors = ConfigValidator(project_path / "deply.yaml").validate(config)
+
+        self.assertIn(
+            "layers[0].collectors[0].must[0]: decorator_name or decorator_regex required",
+            errors,
+        )
+        self.assertIn(
+            "layers[0].collectors[1]: one of must, any_of, or must_not must contain collectors",
+            errors,
+        )
+
+    def test_reports_bool_collector_must_not_errors(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            project_path = Path(temporary_directory)
+            config = {
+                "paths": [str(project_path)],
+                "exclude_files": [],
+                "layers": [
+                    {
+                        "name": "domain",
+                        "collectors": [
+                            {
+                                "type": "bool",
+                                "must_not": [
+                                    {
+                                        "type": "function_name_regex",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+                "ruleset": {},
+            }
+
+            errors = self._validate(config)
+
+        self.assertIn("layers[0].collectors[0].must_not[0].function_name_regex: required", errors)
+
+    def test_reports_rule_errors(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            project_path = Path(temporary_directory)
+            config = {
+                "paths": [str(project_path)],
+                "exclude_files": [],
+                "layers": [
+                    {
+                        "name": "domain",
+                        "collectors": [
+                            {
+                                "type": "class_inherits",
+                                "base_class": "Entity",
+                            }
+                        ],
+                    }
+                ],
+                "ruleset": {
+                    "missing": {
+                        "allow_layer_dependencies": ["domain"],
+                    },
+                    "domain": {
+                        "disallow_layer_dependencies": ["missing"],
+                        "enforce_class_naming": [
+                            {
+                                "type": "unknown",
+                            },
+                            {
+                                "type": "class_name_regex",
+                                "class_name_regex": "[",
+                            },
+                        ],
+                        "enforce_inheritance": [
+                            {
+                                "type": "bool",
+                                "any_of": [
+                                    {
+                                        "type": "class_inherits",
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                },
+            }
+
+            errors = ConfigValidator(project_path / "deply.yaml").validate(config)
+
+        self.assertIn("ruleset.missing: unknown layer: missing", errors)
+        self.assertIn("ruleset.missing.allow_layer_dependencies: unknown rule key", errors)
+        self.assertIn("ruleset.domain.disallow_layer_dependencies[0]: unknown layer: missing", errors)
+        self.assertIn("ruleset.domain.enforce_class_naming[0].type: unknown rule type: unknown", errors)
+        self.assertTrue(
+            any(error.startswith("ruleset.domain.enforce_class_naming[1].class_name_regex: invalid regex") for error in errors)
+        )
+        self.assertIn("ruleset.domain.enforce_inheritance[0].any_of[0].base_class: required", errors)
+
+    def test_reports_rule_shape_errors(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            project_path = Path(temporary_directory)
+            config = {
+                "paths": [str(project_path)],
+                "exclude_files": [],
+                "layers": [
+                    {
+                        "name": "domain",
+                        "collectors": [
+                            {
+                                "type": "class_name_regex",
+                                "class_name_regex": ".*",
+                            }
+                        ],
+                    }
+                ],
+                "ruleset": {
+                    123: {},
+                    "domain": {
+                        "unknown": [],
+                        "disallow_external_imports": "django",
+                        "enforce_function_naming": "not-list",
+                    },
+                },
+            }
+
+            errors = self._validate(config)
+
+        self.assertIn("ruleset: layer names must be non-empty strings", errors)
+        self.assertIn("ruleset.domain.unknown: unknown rule key", errors)
+        self.assertIn("ruleset.domain.disallow_external_imports: must be a list of strings", errors)
+        self.assertIn("ruleset.domain.enforce_function_naming: must be a list", errors)
+
+    def test_reports_rule_required_field_errors(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            project_path = Path(temporary_directory)
+            config = {
+                "paths": [str(project_path)],
+                "exclude_files": [],
+                "layers": [
+                    {
+                        "name": "domain",
+                        "collectors": [
+                            {
+                                "type": "class_name_regex",
+                                "class_name_regex": ".*",
+                            }
+                        ],
+                    }
+                ],
+                "ruleset": {
+                    "domain": {
+                        "enforce_function_naming": [
+                            {
+                                "type": "function_name_regex",
+                            }
+                        ],
+                        "enforce_class_decorator_usage": [
+                            {
+                                "type": "class_decorator_name_regex",
+                            }
+                        ],
+                        "enforce_function_decorator_usage": [
+                            {
+                                "type": "function_decorator_name_regex",
+                            }
+                        ],
+                        "enforce_inheritance": [
+                            {
+                                "type": "class_inherits",
+                            },
+                            {
+                                "type": "bool",
+                                "must_not": [
+                                    {
+                                        "type": "class_name_regex",
+                                    }
+                                ],
+                            },
+                        ],
+                    }
+                },
+            }
+
+            errors = self._validate(config)
+
+        self.assertIn("ruleset.domain.enforce_function_naming[0].function_name_regex: required", errors)
+        self.assertIn("ruleset.domain.enforce_class_decorator_usage[0].decorator_name_regex: required", errors)
+        self.assertIn("ruleset.domain.enforce_function_decorator_usage[0].decorator_name_regex: required", errors)
+        self.assertIn("ruleset.domain.enforce_inheritance[0].base_class: required", errors)
+        self.assertIn("ruleset.domain.enforce_inheritance[1].must_not[0].class_name_regex: required", errors)
+
+    def test_continues_after_unknown_rule_key(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            project_path = Path(temporary_directory)
+            config = {
+                "paths": [str(project_path)],
+                "exclude_files": [],
+                "layers": [
+                    {
+                        "name": "domain",
+                        "collectors": [
+                            {
+                                "type": "class_name_regex",
+                                "class_name_regex": ".*",
+                            }
+                        ],
+                    }
+                ],
+                "ruleset": {
+                    "domain": {
+                        "unknown": [],
+                        "disallow_layer_dependencies": "not-list",
+                    }
+                },
+            }
+
+            errors = self._validate(config)
+
+        self.assertIn("ruleset.domain.unknown: unknown rule key", errors)
+        self.assertIn("ruleset.domain.disallow_layer_dependencies: must be a list of strings", errors)
+        self.assertFalse(any("unknown layer" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_main_and_config_parser.py
+++ b/tests/test_main_and_config_parser.py
@@ -10,7 +10,7 @@ import yaml
 
 from deply import __version__
 from deply.config_parser import ConfigParser
-from deply.main import main
+from deply.main import main, validate_configuration
 
 
 class TestMainAndConfigParser(unittest.TestCase):
@@ -44,6 +44,17 @@ class TestMainAndConfigParser(unittest.TestCase):
 
         self.assertEqual(basic_config_function.call_args.kwargs["level"], logging.DEBUG)
 
+    def test_main_sets_info_log_level_by_default(self):
+        with patch.object(sys, "argv", ["main.py", "analyze"]), patch(
+            "deply.main.DeplyRunner"
+        ) as runner_class, patch("deply.main.logging.basicConfig") as basic_config_function:
+            runner_class.return_value.run.return_value = True
+
+            with self.assertRaises(SystemExit):
+                main()
+
+        self.assertEqual(basic_config_function.call_args.kwargs["level"], logging.INFO)
+
     def test_config_parser_sets_default_path_when_paths_not_provided(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             configuration_path = Path(temporary_directory) / "deply.yaml"
@@ -65,6 +76,136 @@ class TestMainAndConfigParser(unittest.TestCase):
         self.assertEqual(parsed_configuration["exclude_files"], [])
         self.assertEqual(parsed_configuration["layers"], [])
         self.assertEqual(parsed_configuration["ruleset"], {})
+
+    def test_config_parser_rejects_invalid_deply_root(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            configuration_path = Path(temporary_directory) / "deply.yaml"
+            configuration_path.write_text(yaml.dump({"deply": []}))
+
+            with self.assertRaises(ValueError) as context:
+                ConfigParser(configuration_path).parse()
+
+        self.assertIn("Invalid deply configuration format", str(context.exception))
+
+    def test_main_validate_exits_zero_for_valid_configuration(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            project_path = Path(temporary_directory) / "project"
+            project_path.mkdir()
+            configuration_path = Path(temporary_directory) / "deply.yaml"
+            configuration_path.write_text(
+                yaml.dump(
+                    {
+                        "deply": {
+                            "paths": [str(project_path)],
+                            "exclude_files": [],
+                            "layers": [
+                                {
+                                    "name": "domain",
+                                    "collectors": [
+                                        {
+                                            "type": "class_inherits",
+                                            "base_class": "Entity",
+                                        }
+                                    ],
+                                }
+                            ],
+                            "ruleset": {},
+                        }
+                    }
+                )
+            )
+
+            with patch.object(sys, "argv", ["main.py", "validate", "--config", str(configuration_path)]), patch(
+                "deply.main.DeplyRunner"
+            ) as runner_class, patch("sys.stdout", new=StringIO()) as output_stream:
+                with self.assertRaises(SystemExit) as exit_context:
+                    main()
+
+        self.assertEqual(exit_context.exception.code, 0)
+        runner_class.assert_not_called()
+        self.assertIn(f"Configuration is valid: {configuration_path}", output_stream.getvalue())
+
+    def test_main_validate_exits_one_for_invalid_configuration(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            configuration_path = Path(temporary_directory) / "deply.yaml"
+            configuration_path.write_text(
+                yaml.dump(
+                    {
+                        "deply": {
+                            "paths": ["/path/that/does/not/exist"],
+                            "exclude_files": ["["],
+                            "layers": [],
+                            "ruleset": {},
+                        }
+                    }
+                )
+            )
+
+            with patch.object(sys, "argv", ["main.py", "validate", "--config", str(configuration_path)]), patch(
+                "sys.stderr", new=StringIO()
+            ) as error_stream:
+                with self.assertRaises(SystemExit) as exit_context:
+                    main()
+
+        self.assertEqual(exit_context.exception.code, 1)
+        error_output = error_stream.getvalue()
+        self.assertEqual(error_output.splitlines()[0], "Invalid deply configuration:")
+        self.assertIn("paths[0]: path does not exist: /path/that/does/not/exist", error_output)
+        self.assertIn("layers: must contain at least one layer", error_output)
+
+    def test_main_validate_exits_one_for_parser_error(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            configuration_path = Path(temporary_directory) / "deply.yaml"
+            configuration_path.write_text(yaml.dump({"deply": []}))
+
+            with patch.object(sys, "argv", ["main.py", "validate", "--config", str(configuration_path)]), patch(
+                "sys.stderr", new=StringIO()
+            ) as error_stream:
+                with self.assertRaises(SystemExit) as exit_context:
+                    main()
+
+        self.assertEqual(exit_context.exception.code, 1)
+        self.assertEqual(error_stream.getvalue().splitlines()[0], "Invalid deply configuration:")
+        self.assertIn("Invalid deply configuration format", error_stream.getvalue())
+
+    def test_main_validate_exits_one_for_invalid_yaml(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            configuration_path = Path(temporary_directory) / "deply.yaml"
+            configuration_path.write_text("deply: [")
+
+            with patch.object(sys, "argv", ["main.py", "validate", "--config", str(configuration_path)]), patch(
+                "sys.stderr", new=StringIO()
+            ) as error_stream:
+                with self.assertRaises(SystemExit) as exit_context:
+                    main()
+
+        self.assertEqual(exit_context.exception.code, 1)
+        self.assertEqual(error_stream.getvalue().splitlines()[0], "Invalid deply configuration:")
+
+    def test_validate_configuration_passes_config_path_to_validator(self):
+        with patch("deply.main.ConfigParser") as parser_class, patch(
+            "deply.main.ConfigValidator"
+        ) as validator_class, patch("sys.stdout", new=StringIO()):
+            parser_class.return_value.parse.return_value = {"paths": []}
+            validator_class.return_value.validate.return_value = []
+
+            result = validate_configuration("custom.yaml")
+
+        self.assertTrue(result)
+        validator_class.assert_called_once_with(Path("custom.yaml"))
+        validator_class.return_value.validate.assert_called_once_with({"paths": []})
+
+    def test_validate_configuration_prints_invalid_header(self):
+        with patch("deply.main.ConfigParser") as parser_class, patch("deply.main.ConfigValidator") as validator_class:
+            parser_class.return_value.parse.return_value = {}
+            validator_class.return_value.validate.return_value = ["paths: required"]
+
+            with patch("sys.stderr", new=StringIO()) as error_stream:
+                result = validate_configuration("custom.yaml")
+
+        self.assertFalse(result)
+        self.assertEqual(error_stream.getvalue().splitlines()[0], "Invalid deply configuration:")
+        self.assertIn("- paths: required", error_stream.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `deply validate` to validate `deply.yaml` without running Python analysis.
- Add `ConfigValidator` coverage for schema shape, regexes, collectors, rules, and layer references.
- Update mutation scope to use `source_paths` and include validation CLI glue.
- Update CLI/config docs for validation behavior.

## Validation
- `./.venv/bin/python -m unittest tests.test_config_validator tests.test_main_and_config_parser`
- `make check`
- `./.venv/bin/mutmut print-time-estimates`
- `make mutation`
- `git diff --check`

## Notes
`gh` is not installed in this environment, so the branch was pushed with local git and the PR was opened through the GitHub connector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command to validate configuration files without running analysis.
  * Updated CLI and docs to use the newer `--config` option format and added validation examples.
  * Documented configuration validation as a supported capability.

* **Bug Fixes**
  * Improved configuration checks so invalid settings, paths, and rule definitions are reported clearly.
  * Added clearer success and failure messages, with appropriate exit codes for validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->