### PR TITLE
Add Deply config skill

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include LICENSE
 include requirements.txt
 include config_example.yaml
 recursive-include deply/rules *.py
+recursive-include skills *

--- a/README.md
+++ b/README.md
@@ -94,6 +94,18 @@ deply analyze --mermaid
 deply --help
 ```
 
+## Agent Skill
+
+Deply v1.0.0 includes a portable Agent Skill at `skills/deply-config/` for Codex, Claude Code, and other Agent Skills-compatible assistants. It helps an assistant inspect a Python project, generate `deply.yaml` with `light`, `medium`, or `strict` architecture rules, validate it with `deply validate`, run analysis, and add Makefile/CI/docs integration.
+
+Use it with:
+
+```text
+Use $deply-config to create and validate a Deply architecture config for this Python project.
+```
+
+See [Agent Skill](https://vashkatsi.github.io/deply/doc/skills.html) for installation instructions.
+
 ## Features
 
 - **Layer-Based Analysis**: Define project layers and restrict their dependencies to enforce modularity.
@@ -155,7 +167,7 @@ A plan to evolve Deply into a must-have architectural guardian for Python projec
   🔲 Dependency graph caching  
   🔲 Custom rules system  
   🔲 FastAPI/Django/Flask presets  
-  🔲 LLM skill creation helpers
+  ✅ LLM skill creation helpers
   ✅ Third-party import restrictions (`disallow_external_imports`)
 
 ## Further Documentation
@@ -165,6 +177,7 @@ A plan to evolve Deply into a must-have architectural guardian for Python projec
 - [Rules](https://vashkatsi.github.io/deply/doc/rules.html) - Lists the different rule types supported by Deply
 - [Mermaid Diagrams](https://vashkatsi.github.io/deply/doc/mermaid.html) - Overview of the diagram generation capabilities
 - [Command Line Interface](https://vashkatsi.github.io/deply/doc/cli.html) - Advice for using the CLI
+- [Agent Skill](https://vashkatsi.github.io/deply/doc/skills.html) - Install and use the Deply Config Agent Skill
 
 ## Author
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -51,6 +51,11 @@ Welcome to the Deply documentation! This documentation will help you understand 
    - Output Formats
    - Examples
 
+8. [Agent Skill]({{ site.baseurl }}/doc/skills.html)
+   - Codex and Claude Code installation
+   - Config generation workflow
+   - CI integration
+
 ## About Deply
 
 Deply is a standalone Python tool for enforcing architectural patterns and dependencies in large Python projects. By analyzing code structure and dependencies, this tool ensures that architectural rules are followed, promoting cleaner, more maintainable, and modular codebases.

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -21,11 +21,19 @@ pip install deply
 After installation, you can start using Deply by following these steps:
 
 1. Create a configuration file named `deply.yaml` in your project root
-2. Run the analysis command:
+2. Validate the configuration:
+
+```bash
+deply validate --config=deply.yaml
+```
+
+3. Run the analysis command:
 
 ```bash
 deply analyze
 ```
+
+You can also use the [Deply Config Agent Skill](skills.html) with Codex, Claude Code, or another Agent Skills-compatible assistant to generate the configuration interactively.
 
 ## Configuration
 

--- a/doc/skills.md
+++ b/doc/skills.md
@@ -1,0 +1,79 @@
+---
+layout: default
+title: Agent Skill
+nav_order: 9
+---
+
+# Deply Config Agent Skill
+
+Deply v1.0.0 ships a portable Agent Skill at `skills/deply-config/`. Use it with Codex, Claude Code, or any Agent Skills-compatible assistant to create and validate `deply.yaml` for a Python project.
+
+The skill guides the assistant through:
+
+- repository discovery before asking questions
+- deterministic discovery checklist for Python roots, frameworks, CI, docs, suppressions, and monorepos
+- create/update mode for new or improved configs
+- audit mode for existing `deply.yaml`, CI, docs, and suppressions
+- violation triage after `deply analyze`
+- architecture recipes for layered, hexagonal, Django, FastAPI, modular monolith, monorepo, and trading/ccxt-style systems
+- `light`, `medium`, and `strict` architecture presets
+- monorepo guidance for `apps/*`, `services/*`, `packages/*`, and `src/*`
+- framework-aware collectors for Django, FastAPI, Flask, Celery, and SQLAlchemy
+- install snippets for `pip`, `pipx`, `uv`, and `poetry`
+- `deply validate --config=deply.yaml`
+- `deply analyze --parallel --config=deply.yaml`
+- Makefile, CI, and documentation updates
+
+## Installation
+
+For Codex, copy the skill folder into your Codex skills directory:
+
+```bash
+mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills"
+cp -R skills/deply-config "${CODEX_HOME:-$HOME/.codex}/skills/deply-config"
+```
+
+For Claude Code, copy it into your user or project skills directory:
+
+```bash
+mkdir -p "$HOME/.claude/skills"
+cp -R skills/deply-config "$HOME/.claude/skills/deply-config"
+```
+
+For project-local Claude Code usage:
+
+```bash
+mkdir -p .claude/skills
+cp -R skills/deply-config .claude/skills/deply-config
+```
+
+For other agents, point the agent at the `skills/deply-config/` folder as an Agent Skills-compatible skill.
+
+## Usage
+
+Ask your assistant:
+
+```text
+Use $deply-config to create and validate a Deply architecture config for this Python project.
+```
+
+The assistant should inspect the repository first, ask only for architecture intent, choose a matching architecture recipe, generate or audit `deply.yaml`, validate it, run analysis, triage violations, scan existing `deply:ignore` suppressions, and then add local/CI/docs integration when requested.
+
+## Recommended CI Command
+
+```bash
+deply validate --config=deply.yaml
+deply analyze --parallel --config=deply.yaml
+```
+
+For GitHub Actions, prefer:
+
+```bash
+deply analyze --parallel --report-format=github-actions --config=deply.yaml
+```
+
+If adopting Deply in a legacy project with existing violations, use an explicit temporary ratchet only after recording the current violation count:
+
+```bash
+deply analyze --parallel --config=deply.yaml --max-violations=12
+```

--- a/skills/deply-config/SKILL.md
+++ b/skills/deply-config/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: deply-config
+description: Create, audit, validate, and integrate Deply v1.0.0 architecture configuration files for Python projects. Use when the user asks to generate, improve, or review deply.yaml, set light/medium/strict architecture rules, support monorepos, add Deply validation or analysis to CI/Makefile, document Deply architecture boundaries, or adopt Deply in an existing Python repository.
+license: MIT
+metadata:
+  version: "1.0.0"
+---
+
+# Deply Config
+
+Use this skill to create or audit a production-ready `deply.yaml` for a Python project and wire it into local checks, CI, and documentation.
+
+## Workflow
+
+1. Inspect the repository before asking questions:
+   - Package tree and Python source roots.
+   - `pyproject.toml`, `setup.py`, `setup.cfg`, requirements files, lockfiles.
+   - `Makefile`, `.github/workflows/`, `.gitlab-ci.yml`, tox/nox/pre-commit config.
+   - Existing docs, architecture notes, and framework imports.
+   - Existing `deply.yaml` files and `deply:ignore` / `deply:ignore-file` suppressions.
+2. Ask only for intent that cannot be discovered:
+   - Preserve current architecture or enforce a target architecture.
+   - Strictness: `light`, `medium`, or `strict`.
+   - CI rollout: fail immediately or adopt with a temporary `--max-violations=N` ratchet.
+3. Read the needed references:
+   - `references/discovery.md` first for deterministic repository inspection before asking questions.
+   - `references/deply-v1-schema.md` for exact Deply v1.0.0 YAML, collectors, rules, and validation constraints.
+   - `references/architecture-recipes.md` when choosing a target architecture style.
+   - `references/presets.md` for `light`, `medium`, and `strict` rule sets.
+   - `references/framework-presets.md` when the repo uses Django, FastAPI, Flask, Celery, or SQLAlchemy.
+   - `references/adoption-and-audit.md` when auditing an existing config or adopting Deply in a legacy project.
+   - `references/monorepo.md` when the repo has multiple apps, packages, or services.
+   - `references/violation-triage.md` when `deply analyze` reports violations.
+   - `references/ci-and-docs.md` when adding Makefile, CI, or documentation changes.
+4. Choose the mode:
+   - Create/update mode: generate or improve `deply.yaml` with public root key `deply:`.
+   - Audit mode: review existing config, CI, docs, and suppressions before proposing changes.
+5. Run `deply validate --config=deply.yaml` from the project root.
+6. Run `deply analyze --parallel --config=deply.yaml` from the project root.
+7. If violations exist, triage them before editing. Fix collectors/excludes first. Only use `--max-violations=N` when the user chooses non-blocking adoption.
+8. Add local command, CI step, and short architecture docs when requested.
+9. Finish with the output contract below.
+
+## Rules
+
+- Prefer the smallest config that enforces the intended boundaries.
+- Do not invent unsupported keys such as `allow_layer_dependencies`.
+- Do not add generated files, tests, migrations, virtualenvs, build output, or vendored code to analysis scope.
+- Keep domain/business layers independent from frameworks, persistence, transport, and SDKs when using `medium` or `strict`.
+- Do not add new Deply suppressions unless the user accepts a specific architectural reason.
+- Report existing suppressions separately from new violations.
+- Validate every config with the installed Deply CLI before presenting it as complete.
+
+## Final Output Contract
+
+End every run with:
+
+- Changed files.
+- Mode: create/update or audit.
+- Strictness: `light`, `medium`, `strict`, or `not changed`.
+- Validation command and result.
+- Analyze command and result.
+- Current violation count.
+- Existing suppression count and any new suppressions added.
+- CI behavior: blocking, non-blocking, ratchet with exact `--max-violations=N`, or not changed.
+- Follow-up work, only if required to finish adoption safely.

--- a/skills/deply-config/agents/openai.yaml
+++ b/skills/deply-config/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Deply Config"
+  short_description: "Generate Deply architecture configs"
+  default_prompt: "Use $deply-config to create and validate a Deply architecture config for this Python project."

--- a/skills/deply-config/references/adoption-and-audit.md
+++ b/skills/deply-config/references/adoption-and-audit.md
@@ -1,0 +1,64 @@
+# Adoption and Audit
+
+Use this when the project already has `deply.yaml`, CI wiring, documentation, or Deply suppressions.
+
+## Existing Config Audit
+
+Check:
+
+- Config uses public `deply:` root or parser-compatible top-level shape.
+- No unsupported keys such as `allow_layer_dependencies`, severities, wildcards, or custom rule names.
+- `paths` exist and do not point at generated or dependency directories.
+- `exclude_files` excludes tests, migrations, generated files, build output, virtualenvs, caches, and vendored code without hiding real source layers.
+- Every layer has at least one specific collector.
+- `directory` collectors point at real package/module boundaries.
+- Regex collectors use single-quoted YAML strings when they contain backslashes.
+- Rule layer names match declared layer names.
+- `disallow_external_imports` protects domain/application layers from framework, persistence, HTTP, queue, cloud, SDK, and exchange/client packages where appropriate.
+- Makefile/CI runs both `deply validate` and `deply analyze`.
+- Docs describe actual configured layers and commands.
+
+## Weak Config Signals
+
+Prefer fixing these before adding more rules:
+
+- One layer catches most files.
+- Collectors match tests or migrations by accident.
+- Rules only document architecture but cannot fail in CI.
+- `exclude_files` hides source directories to make analysis pass.
+- Strict rules are configured but CI uses a high permanent `--max-violations`.
+- Suppressions exist without a reviewed architectural reason.
+
+## Suppression Policy
+
+Scan before changing config:
+
+```bash
+rg -n "deply:ignore|deply:ignore-file" .
+```
+
+Rules:
+
+- Count existing suppressions and report them.
+- Do not add suppressions to make a new config pass.
+- Prefer collector fixes, excludes for non-source files, or a temporary ratchet.
+- Add a suppression only when the user accepts a specific exception that cannot be modeled cleanly in `deply.yaml`.
+- Document why new suppressions are acceptable in the final response or project docs.
+
+## Debt Adoption
+
+Use this flow for legacy projects:
+
+1. Generate the target config.
+2. Run `deply validate --config=deply.yaml`.
+3. Run `deply analyze --parallel --config=deply.yaml`.
+4. If violations are real and accepted temporarily, rerun with exact current count:
+
+```bash
+deply analyze --parallel --config=deply.yaml --max-violations=12
+```
+
+5. Put the same exact count in CI.
+6. Document that the number must only decrease.
+
+Do not choose the ratchet count by guessing. Use the actual current violation count from Deply output.

--- a/skills/deply-config/references/architecture-recipes.md
+++ b/skills/deply-config/references/architecture-recipes.md
@@ -1,0 +1,112 @@
+# Architecture Recipes
+
+Use these to choose layer names and dependency direction. They are starting points, not exhaustive configs.
+
+## Layered App
+
+Typical layers:
+
+- `interface`: CLI, HTTP, workers.
+- `application`: use cases and orchestration.
+- `domain`: business rules and entities.
+- `infrastructure`: database, HTTP clients, queues, SDKs.
+
+Direction:
+
+- Interface depends inward.
+- Application depends on domain.
+- Domain depends on nothing outward.
+- Infrastructure is called through application/domain abstractions where the codebase supports that style.
+
+## Hexagonal / Ports And Adapters
+
+Typical layers:
+
+- `domain`: entities, value objects, domain services.
+- `application`: use cases and ports.
+- `adapters`: persistence, exchange, HTTP, queue, framework adapters.
+- `interface`: web, CLI, worker entrypoints.
+
+Direction:
+
+- Domain has no framework, persistence, transport, SDK, or exchange imports.
+- Application depends on domain, not concrete adapters.
+- Adapters and interface depend inward.
+
+## Django Pragmatic
+
+Typical layers:
+
+- `models`: Django ORM models.
+- `views`: views, viewsets, serializers, routes.
+- `services`: business/application services.
+- `tasks`: Celery tasks.
+
+Direction:
+
+- Views and tasks may depend on services.
+- Services should avoid direct view/framework concerns.
+- If user wants strict DDD, split `domain` from Django `models`; otherwise treat Django models as persistence/domain hybrid and avoid over-modeling.
+
+## FastAPI Service
+
+Typical layers:
+
+- `interface`: routers, dependencies, request/response DTOs.
+- `application`: use cases.
+- `domain`: business objects.
+- `infrastructure`: database, external clients, queues.
+
+Direction:
+
+- Routers depend on application.
+- Application depends on domain.
+- Domain should not import FastAPI, Starlette, SQLAlchemy, HTTP clients, or exchange SDKs in strict mode.
+
+## Modular Monolith
+
+Typical layers:
+
+- `billing_domain`, `billing_application`, `billing_infrastructure`.
+- `identity_domain`, `identity_application`, `identity_infrastructure`.
+- `shared_kernel` only when it already exists and is stable.
+
+Direction:
+
+- Modules should not depend on each other's infrastructure.
+- Cross-module dependencies should go through application APIs or shared domain concepts.
+- Avoid creating `shared` catch-all layers.
+
+## Shared Core Monorepo
+
+Typical layers:
+
+- `core_domain`.
+- `core_application`.
+- `api_interface`.
+- `worker_interface`.
+- `shared_infrastructure`.
+
+Direction:
+
+- Apps/services depend on core.
+- Core does not depend on apps/services.
+- Shared infrastructure should not leak into core domain.
+
+## Trading / ccxt-Style System
+
+Typical layers:
+
+- `strategy_domain`: signals, strategy rules, market concepts.
+- `risk_domain`: limits, sizing, exposure rules.
+- `execution_application`: order orchestration and idempotency.
+- `exchange_adapters`: ccxt clients, exchange quirks, retry/rate-limit handling.
+- `market_data_infrastructure`: feeds, storage, cache.
+- `interface`: CLI, API, schedulers, bots.
+
+Direction:
+
+- Strategy and risk domains must not import `ccxt`, HTTP clients, persistence, or framework code.
+- Execution application coordinates ports and domain decisions.
+- Exchange adapters depend inward and own exchange-specific failure modes.
+- CI should block new domain imports from `ccxt`, `requests`, `httpx`, SDKs, and persistence packages in medium/strict mode.

--- a/skills/deply-config/references/ci-and-docs.md
+++ b/skills/deply-config/references/ci-and-docs.md
@@ -1,0 +1,146 @@
+# CI and Documentation Snippets
+
+Use these snippets after `deply.yaml` validates.
+
+## Install Commands
+
+Use a pinned Deply version in CI for reproducibility.
+
+`pip`:
+
+```bash
+python -m pip install "deply==1.0.0"
+deply validate --config=deply.yaml
+deply analyze --parallel --config=deply.yaml
+```
+
+`pipx`:
+
+```bash
+pipx run --spec "deply==1.0.0" deply validate --config=deply.yaml
+pipx run --spec "deply==1.0.0" deply analyze --parallel --config=deply.yaml
+```
+
+`uv`:
+
+```bash
+uvx --from "deply==1.0.0" deply validate --config=deply.yaml
+uvx --from "deply==1.0.0" deply analyze --parallel --config=deply.yaml
+```
+
+`poetry`:
+
+```bash
+poetry add --group dev "deply==1.0.0"
+poetry run deply validate --config=deply.yaml
+poetry run deply analyze --parallel --config=deply.yaml
+```
+
+## Makefile
+
+Add a target that validates the config and runs analysis:
+
+```make
+.PHONY: architecture-check
+
+architecture-check:
+	deply validate --config=deply.yaml
+	deply analyze --parallel --config=deply.yaml
+```
+
+For legacy adoption with accepted current debt:
+
+```make
+architecture-check:
+	deply validate --config=deply.yaml
+	deply analyze --parallel --config=deply.yaml --max-violations=$(DEPLY_MAX_VIOLATIONS)
+```
+
+Use an exact numeric value in CI, not an untracked environment default.
+
+## GitHub Actions
+
+`pip` install:
+
+```yaml
+- name: Install Deply
+  run: |
+    python -m pip install --upgrade pip
+    python -m pip install "deply==1.0.0"
+
+- name: Validate Deply config
+  run: deply validate --config=deply.yaml
+
+- name: Check architecture
+  run: deply analyze --parallel --report-format=github-actions --config=deply.yaml
+```
+
+`uv` install:
+
+```yaml
+- name: Install uv
+  uses: astral-sh/setup-uv@v5
+
+- name: Validate Deply config
+  run: uvx --from "deply==1.0.0" deply validate --config=deply.yaml
+
+- name: Check architecture
+  run: uvx --from "deply==1.0.0" deply analyze --parallel --report-format=github-actions --config=deply.yaml
+```
+
+Legacy ratchet:
+
+```yaml
+- name: Check architecture
+  run: deply analyze --parallel --report-format=github-actions --config=deply.yaml --max-violations=12
+```
+
+## GitLab CI
+
+```yaml
+architecture:
+  image: python:3.12
+  script:
+    - python -m pip install --upgrade pip
+    - python -m pip install "deply==1.0.0"
+    - deply validate --config=deply.yaml
+    - deply analyze --parallel --config=deply.yaml
+```
+
+## Documentation
+
+Add a short architecture section to `README.md` or `docs/architecture.md`:
+
+````markdown
+## Architecture Checks
+
+This project uses Deply to enforce Python architecture boundaries.
+
+Local check:
+
+```bash
+deply validate --config=deply.yaml
+deply analyze --parallel --config=deply.yaml
+```
+
+Configured layers:
+
+- `domain`: business rules and entities. No framework or persistence imports.
+- `application`: use cases and orchestration.
+- `infrastructure`: database, HTTP, queue, SDK, and framework adapters.
+- `interface`: CLI, web, API, worker entrypoints.
+
+Suppression policy:
+
+- Existing `deply:ignore` and `deply:ignore-file` comments are reviewed during adoption.
+- New suppressions require a specific architectural reason in review.
+- Prefer config fixes or a temporary `--max-violations=N` ratchet over hiding violations.
+
+CI behavior:
+
+- New projects should fail on any violation.
+- Legacy projects may temporarily use an exact `--max-violations=N` value equal to the current violation count.
+- Ratchet values should only decrease.
+````
+
+Keep documentation factual. Do not describe rules that are not present in `deply.yaml`.

--- a/skills/deply-config/references/deply-v1-schema.md
+++ b/skills/deply-config/references/deply-v1-schema.md
@@ -1,0 +1,138 @@
+# Deply v1.0.0 Schema Reference
+
+Use this as the source of truth for generated `deply.yaml` files.
+
+## File Shape
+
+Always generate the public YAML shape:
+
+```yaml
+deply:
+  paths:
+    - "."
+
+  exclude_files:
+    - '.*/\.venv/.*'
+    - '.*/tests?/.*'
+
+  layers:
+    - name: layer_name
+      collectors:
+        - type: directory
+          directories:
+            - "src/package/path"
+
+  ruleset:
+    layer_name:
+      disallow_layer_dependencies:
+        - other_layer
+```
+
+Run commands from the project root when using relative paths.
+
+## Top-Level Keys
+
+- `paths`: non-empty list of existing paths. Use `"."` for the project root unless a narrower source root is clearly better.
+- `exclude_files`: list of regex strings.
+- `layers`: non-empty list of layer objects.
+- `ruleset`: mapping from layer name to rules.
+
+## Collectors
+
+- `directory`
+  - `directories`: non-empty list of directory names.
+  - Best default for package/module boundaries.
+- `file_regex`
+  - `regex`: regex matching source file path.
+  - Use for framework entrypoints such as views, routes, commands, or adapters.
+- `class_name_regex`
+  - `class_name_regex`: regex matching class names.
+  - Use sparingly for suffix conventions like `.*Service$`.
+- `function_name_regex`
+  - `function_name_regex`: regex matching function names.
+- `class_inherits`
+  - `base_class`: fully qualified base class.
+  - Use for Django models, DRF views, SQLAlchemy declarative bases, etc.
+- `decorator_usage`
+  - `decorator_name` or `decorator_regex`.
+  - Use for Celery tasks, FastAPI routes, auth-protected handlers, etc.
+- `bool`
+  - `must`, `any_of`, `must_not`: lists of nested collectors.
+  - At least one group must be non-empty.
+- `custom`
+  - `class`: import path to a `BaseCollector` subclass.
+  - Avoid in generated v1 configs unless the project already has one.
+
+All collectors may use optional `exclude_files_regex`.
+
+## Rule Keys
+
+- `disallow_layer_dependencies`
+  - List of layer names the source layer must not depend on.
+- `disallow_external_imports`
+  - List of package roots disallowed in the layer.
+  - Use for blocking framework, persistence, HTTP, queue, or SDK imports from domain/application layers.
+- `enforce_class_naming`
+  - List of rule configs.
+- `enforce_function_naming`
+  - List of rule configs.
+- `enforce_class_decorator_usage`
+  - List of rule configs.
+- `enforce_function_decorator_usage`
+  - List of rule configs.
+- `enforce_inheritance`
+  - List of rule configs.
+
+Unsupported: `allow_layer_dependencies`, wildcards, severity levels, inline comments inside `ruleset`, and custom rule names.
+
+## Rule Config Types
+
+```yaml
+type: class_name_regex
+class_name_regex: '.*Service$'
+```
+
+```yaml
+type: function_name_regex
+function_name_regex: '^handle_.*'
+```
+
+```yaml
+type: class_decorator_name_regex
+decorator_name_regex: 'dataclass|pydantic\.dataclasses\.dataclass'
+```
+
+```yaml
+type: function_decorator_name_regex
+decorator_name_regex: 'app\.task|shared_task'
+```
+
+```yaml
+type: class_inherits
+base_class: "django.db.models.Model"
+```
+
+```yaml
+type: bool
+any_of:
+  - type: class_inherits
+    base_class: "django.db.models.Model"
+  - type: class_inherits
+    base_class: "django.contrib.auth.models.AbstractUser"
+```
+
+## Validation Contract
+
+Always run:
+
+```bash
+deply validate --config=deply.yaml
+```
+
+Then run:
+
+```bash
+deply analyze --parallel --config=deply.yaml
+```
+
+If validation fails, fix the config. If analysis fails with violations, decide whether to tighten collectors/excludes, change architecture, or adopt with a temporary ratchet.

--- a/skills/deply-config/references/discovery.md
+++ b/skills/deply-config/references/discovery.md
@@ -1,0 +1,55 @@
+# Discovery
+
+Read this before asking the user questions. Prefer facts from the repository over guesses.
+
+## Repository Shape
+
+Find Python source roots and package boundaries:
+
+```bash
+find . -maxdepth 4 -type f \( -name pyproject.toml -o -name setup.py -o -name setup.cfg -o -name requirements.txt \)
+find . -maxdepth 4 -type f -name "__init__.py" | sed 's#/__init__.py##' | sort
+find . -maxdepth 3 -type d \( -name apps -o -name services -o -name packages -o -name src \)
+```
+
+Look for existing architecture signals:
+
+```bash
+find . -maxdepth 4 -type d \( -name domain -o -name application -o -name infrastructure -o -name adapters -o -name interface -o -name api \)
+find . -maxdepth 4 -type f \( -name "*service*.py" -o -name "*repository*.py" -o -name "*handler*.py" -o -name "*router*.py" -o -name "*view*.py" \)
+```
+
+## Frameworks And Tooling
+
+Detect dependencies:
+
+```bash
+rg -n "django|fastapi|flask|celery|sqlalchemy|pydantic|requests|httpx|boto3|ccxt" pyproject.toml setup.py setup.cfg requirements*.txt poetry.lock uv.lock Pipfile.lock 2>/dev/null
+```
+
+Detect imports when dependency files are incomplete:
+
+```bash
+rg -n "^(from|import) (django|fastapi|flask|celery|sqlalchemy|pydantic|requests|httpx|boto3|ccxt)\\b" .
+```
+
+## Existing Deply Adoption
+
+Check config, suppressions, CI, and docs:
+
+```bash
+find . -maxdepth 4 -type f \( -name "deply.yaml" -o -name "deply.yml" \)
+rg -n "deply:ignore|deply:ignore-file" .
+find . -maxdepth 4 -type f \( -name Makefile -o -name ".gitlab-ci.yml" -o -path "*/.github/workflows/*" \)
+rg -n "deply validate|deply analyze|architecture check|architecture boundary|layer" README* docs doc .github .gitlab-ci.yml Makefile 2>/dev/null
+```
+
+## Ask Only After Discovery
+
+Ask the user only for choices not discoverable from files:
+
+- Current-state guardrails or target architecture.
+- Strictness: `light`, `medium`, or `strict`.
+- Blocking CI or temporary ratchet.
+- Whether ORM models are domain entities or persistence adapters.
+- Whether monorepo services share one architecture policy.

--- a/skills/deply-config/references/framework-presets.md
+++ b/skills/deply-config/references/framework-presets.md
@@ -1,0 +1,148 @@
+# Framework Presets
+
+Apply only when imports, dependencies, or filenames show the framework is used.
+
+## Django
+
+Common collectors:
+
+```yaml
+- name: models
+  collectors:
+    - type: bool
+      any_of:
+        - type: class_inherits
+          base_class: "django.db.models.Model"
+        - type: class_inherits
+          base_class: "django.contrib.auth.models.AbstractUser"
+```
+
+```yaml
+- name: views
+  collectors:
+    - type: file_regex
+      regex: '.*/views\.py$|.*/views/.*\.py$'
+```
+
+Strict domain imports to block:
+
+```yaml
+disallow_external_imports:
+  - django
+  - rest_framework
+  - celery
+  - requests
+  - sqlalchemy
+```
+
+Usually exclude migrations:
+
+```yaml
+exclude_files:
+  - '.*/migrations/.*'
+```
+
+## FastAPI
+
+Common collectors:
+
+```yaml
+- name: interface
+  collectors:
+    - type: bool
+      any_of:
+        - type: file_regex
+          regex: '.*/routers?/.*\.py$'
+        - type: decorator_usage
+          decorator_regex: '.*\.(get|post|put|patch|delete)'
+```
+
+Strict domain imports to block:
+
+```yaml
+disallow_external_imports:
+  - fastapi
+  - starlette
+  - pydantic
+  - sqlalchemy
+  - requests
+```
+
+Block `pydantic` from domain only when the target architecture separates DTOs from domain objects.
+
+## Flask
+
+Common collectors:
+
+```yaml
+- name: interface
+  collectors:
+    - type: bool
+      any_of:
+        - type: file_regex
+          regex: '.*/routes?\.py$|.*/views?\.py$|.*/blueprints?/.*\.py$'
+        - type: decorator_usage
+          decorator_regex: '.*\.route'
+```
+
+Strict domain imports to block:
+
+```yaml
+disallow_external_imports:
+  - flask
+  - werkzeug
+  - sqlalchemy
+  - requests
+```
+
+## Celery
+
+Common collectors:
+
+```yaml
+- name: tasks
+  collectors:
+    - type: bool
+      any_of:
+        - type: file_regex
+          regex: '.*/tasks\.py$|.*/tasks/.*\.py$'
+        - type: decorator_usage
+          decorator_regex: ".*task|shared_task"
+```
+
+Decorator rule:
+
+```yaml
+ruleset:
+  tasks:
+    enforce_function_decorator_usage:
+      - type: function_decorator_name_regex
+        decorator_name_regex: '.*task|shared_task'
+```
+
+Do not force this rule if the task layer contains helper functions.
+
+## SQLAlchemy
+
+Common collectors:
+
+```yaml
+- name: persistence
+  collectors:
+    - type: bool
+      any_of:
+        - type: file_regex
+          regex: '.*/models\.py$|.*/models/.*\.py$'
+        - type: class_inherits
+          base_class: "sqlalchemy.orm.DeclarativeBase"
+```
+
+Strict domain imports to block:
+
+```yaml
+disallow_external_imports:
+  - sqlalchemy
+  - alembic
+```
+
+If the project uses SQLAlchemy models as domain entities, ask whether the target is current-state guardrails or persistence isolation before blocking `sqlalchemy` in domain.

--- a/skills/deply-config/references/monorepo.md
+++ b/skills/deply-config/references/monorepo.md
@@ -1,0 +1,116 @@
+# Monorepo Guidance
+
+Use this when the repository has multiple Python apps, services, packages, or source roots.
+
+## One Config vs Many
+
+Use one root `deply.yaml` when:
+
+- Services share architecture rules.
+- CI should run one architecture check for the whole repo.
+- Layers can be named without ambiguity.
+- Cross-package dependencies are intentional architecture boundaries.
+
+Use multiple configs when:
+
+- Services have different frameworks or architecture styles.
+- One service is legacy and another is strict.
+- Teams own separate packages and CI runs per package.
+- Layer names would need prefixes everywhere to stay clear.
+
+Default to one root config for v1 unless separate services clearly need different rules.
+
+## Paths
+
+Root config example:
+
+```yaml
+deply:
+  paths:
+    - "apps/api"
+    - "packages/core"
+    - "services/worker"
+```
+
+Per-service config example:
+
+```yaml
+deply:
+  paths:
+    - "."
+```
+
+Run per-service configs from the service root, or pass an explicit config path from repo root.
+
+## Layer Naming
+
+For one root config, use unambiguous names:
+
+- `api_interface`
+- `api_application`
+- `core_domain`
+- `worker_tasks`
+- `shared_infrastructure`
+
+For per-service configs, short names are fine:
+
+- `domain`
+- `application`
+- `infrastructure`
+- `interface`
+
+## Common Layouts
+
+`apps/*`:
+
+```yaml
+- name: api_interface
+  collectors:
+    - type: directory
+      directories:
+        - "apps/api/src/api"
+```
+
+`services/*`:
+
+```yaml
+- name: worker_tasks
+  collectors:
+    - type: directory
+      directories:
+        - "services/worker/src/tasks"
+```
+
+`packages/*`:
+
+```yaml
+- name: core_domain
+  collectors:
+    - type: directory
+      directories:
+        - "packages/core/src/core/domain"
+```
+
+`src/*`:
+
+```yaml
+- name: domain
+  collectors:
+    - type: directory
+      directories:
+        - "src/project/domain"
+```
+
+## Rules
+
+Root configs should model cross-package boundaries explicitly:
+
+```yaml
+ruleset:
+  core_domain:
+    disallow_layer_dependencies:
+      - api_interface
+      - shared_infrastructure
+```
+
+Per-service configs should stay service-local and avoid pretending to protect unrelated packages.

--- a/skills/deply-config/references/presets.md
+++ b/skills/deply-config/references/presets.md
@@ -1,0 +1,137 @@
+# Deply Rule Presets
+
+Use these presets as starting points, then adapt to the discovered project structure.
+
+## Light
+
+Goal: document obvious boundaries and catch accidental direct dependencies.
+
+Use when:
+- First Deply adoption.
+- Legacy code has unknown coupling.
+- User wants low false positives.
+
+Pattern:
+- Create layers from existing top-level packages or obvious directories.
+- Prefer `directory` collectors.
+- Add only high-confidence `disallow_layer_dependencies`.
+- Exclude tests, migrations, generated files, virtualenvs, build output, and vendored code.
+- CI can start as validate-only plus optional non-blocking analysis.
+
+Example:
+
+```yaml
+deply:
+  paths:
+    - "."
+  exclude_files:
+    - '.*/\.venv/.*'
+    - '.*/tests?/.*'
+    - '.*/migrations/.*'
+  layers:
+    - name: domain
+      collectors:
+        - type: directory
+          directories:
+            - "src/app/domain"
+    - name: infrastructure
+      collectors:
+        - type: directory
+          directories:
+            - "src/app/infrastructure"
+  ruleset:
+    domain:
+      disallow_layer_dependencies:
+        - infrastructure
+```
+
+## Medium
+
+Goal: enforce normal layered or hexagonal architecture boundaries.
+
+Use when:
+- Project has recognizable domain/application/infrastructure/interface layers.
+- Team wants CI to block new architecture regressions.
+
+Pattern:
+- Layers: `domain`, `application`, `infrastructure`, `interface` or equivalent project names.
+- `domain` must not depend on application, infrastructure, or interface.
+- `application` must not depend on interface, and usually not directly on infrastructure unless project uses pragmatic service wiring.
+- `domain` disallows framework, ORM, HTTP, queue, cloud SDK, and exchange/client imports.
+- `application` disallows interface frameworks and low-level transport packages unless it owns ports.
+
+Example:
+
+```yaml
+deply:
+  paths:
+    - "."
+  exclude_files:
+    - '.*/\.venv/.*'
+    - '.*/tests?/.*'
+    - '.*/migrations/.*'
+  layers:
+    - name: domain
+      collectors:
+        - type: directory
+          directories:
+            - "src/app/domain"
+    - name: application
+      collectors:
+        - type: directory
+          directories:
+            - "src/app/application"
+    - name: infrastructure
+      collectors:
+        - type: directory
+          directories:
+            - "src/app/infrastructure"
+    - name: interface
+      collectors:
+        - type: directory
+          directories:
+            - "src/app/api"
+  ruleset:
+    domain:
+      disallow_layer_dependencies:
+        - application
+        - infrastructure
+        - interface
+      disallow_external_imports:
+        - django
+        - fastapi
+        - flask
+        - sqlalchemy
+        - requests
+    application:
+      disallow_layer_dependencies:
+        - interface
+```
+
+## Strict
+
+Goal: enforce target architecture, not just current layout.
+
+Use when:
+- New project.
+- Architecture boundaries are already intentional.
+- User accepts initial cleanup or ratchet adoption.
+
+Pattern:
+- Use explicit architecture layers and framework adapter layers.
+- Domain has no framework, persistence, HTTP, queue, cloud, SDK, exchange, or CLI imports.
+- Application has no web framework imports and only depends inward.
+- Interface/adapters depend inward but not sideways.
+- Add naming/decorator/inheritance rules only where the project already follows the convention or user explicitly wants it.
+- CI should run validate and analyze.
+
+Strict adoption in legacy repos:
+- Do not weaken the rules silently.
+- If current violations are accepted temporarily, set `--max-violations=N` to the exact current count and document that it must only decrease.
+
+Example CI command:
+
+```bash
+deply validate --config=deply.yaml
+deply analyze --parallel --config=deply.yaml --max-violations=0
+```

--- a/skills/deply-config/references/violation-triage.md
+++ b/skills/deply-config/references/violation-triage.md
@@ -1,0 +1,49 @@
+# Violation Triage
+
+Use this after `deply analyze` reports violations.
+
+## Classify Each Violation
+
+- Real architecture issue: code depends outward or sideways against the chosen architecture.
+- Broad collector: a layer includes tests, migrations, framework glue, generated code, or unrelated modules.
+- Missing layer: dependency target is real architecture surface but no layer models it.
+- Bad layer naming: layer names hide direction, ownership, or service boundaries.
+- Too-strict rule: rule encodes desired future state but user chose current-state guardrails.
+- Legacy debt: violation is real, accepted temporarily, and should be ratcheted down.
+
+## Fix Order
+
+1. Fix collectors and `exclude_files` for false positives.
+2. Add missing layers for real source boundaries.
+3. Adjust rules to match the selected strictness and architecture recipe.
+4. Recommend code changes only when the user explicitly asked to refactor code.
+5. Use `--max-violations=N` last, with exact current count.
+
+Do not add `deply:ignore` comments to make analysis pass. Use suppressions only for reviewed exceptions that cannot be expressed cleanly in config.
+
+## Collector Fixes
+
+Typical fixes:
+
+- Add tests, migrations, generated files, caches, build output, and vendored code to `exclude_files`.
+- Narrow `directory` collectors to the actual package root.
+- Replace a broad `file_regex` with `directory` when a module boundary exists.
+- Split a mixed layer into explicit layers when one layer catches unrelated code.
+
+## Rule Fixes
+
+Typical fixes:
+
+- Move from strict target rules to `light`/`medium` rules when user wants current-state adoption.
+- Keep domain external import restrictions strict when the user wants framework-free domain.
+- Do not add unsupported allow rules. Deply models restrictions with `disallow_layer_dependencies`.
+
+## Final Report For Violations
+
+Report unresolved violations as:
+
+- Count.
+- Classification.
+- Recommended action.
+- Whether CI blocks, does not block, or uses an exact ratchet.
+- Any follow-up refactor needed outside config.


### PR DESCRIPTION
## Summary
- Add a portable Deply Config Agent Skill for creating, auditing, validating, and integrating `deply.yaml`.
- Add focused references for v1 schema, strictness presets, framework presets, adoption/audit, monorepos, discovery, violation triage, architecture recipes, and CI/docs snippets.
- Document skill installation and usage in the project docs and include skills in source distributions.

## Test Plan
- `./.venv/bin/python /Users/archil/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/deply-config`
- `git diff --check`
- `rg -n "TODO|allow_layer_dependencies|\\[TODO" skills/deply-config doc/skills.md` (only forbidden-key guidance and valid `disallow_layer_dependencies` matches)
- Temp fixture smoke test: `light`, `medium`, and `strict` configs passed `deply validate` and `deply analyze --parallel` with 0 violations.

Skipped `make check` because no Python runtime files changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Agent Skill for generating and validating architecture configuration interactively.
  * Included packaged skill resources so they are available in source distributions.

* **Documentation**
  * Expanded setup and getting-started guides with validation and analysis steps.
  * Added detailed guidance for installation, CI usage, architecture patterns, adoption, and violation triage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->